### PR TITLE
Fix for incorrect storage of concrete action id

### DIFF
--- a/testar/src/nl/ou/testar/StateModel/Persistence/OrientDB/Hydrator/SequenceStepHydrator.java
+++ b/testar/src/nl/ou/testar/StateModel/Persistence/OrientDB/Hydrator/SequenceStepHydrator.java
@@ -45,6 +45,6 @@ public class SequenceStepHydrator implements EntityHydrator<EdgeEntity> {
         edgeEntity.addPropertyValue("timestamp", new PropertyValue(OType.DATETIME, date));
 
         // add the concrete action id
-        edgeEntity.addPropertyValue("concreteActionId", new PropertyValue(OType.STRING, ((SequenceStep) source).getConcreteAction()));
+        edgeEntity.addPropertyValue("concreteActionId", new PropertyValue(OType.STRING, ((SequenceStep) source).getConcreteAction().getActionId()));
     }
 }


### PR DESCRIPTION
This is a fix for the incorrect storage of the concrete action id in the OrientDB data store.