### PR TITLE
Change Spy mode flow

### DIFF
--- a/testar/resources/settings/web_generic/Protocol_web_generic.java
+++ b/testar/resources/settings/web_generic/Protocol_web_generic.java
@@ -50,6 +50,7 @@ public class Protocol_web_generic extends DesktopProtocol {
 	 * This method can be used to perform initial setup work
 	 * @param   settings   the current TESTAR settings as specified by the user.
 	 */
+	@Override
 	protected void initialize(Settings settings){
 		super.initialize(settings);
 		initBrowser();
@@ -73,6 +74,7 @@ public class Protocol_web_generic extends DesktopProtocol {
 	 * state is erroneous and if so why.
 	 * @return  the current state of the SUT with attached oracle.
 	 */
+	@Override
 	protected State getState(SUT system) throws StateBuildException{
 		
 		State state = super.getState(system);

--- a/testar/resources/settings/web_one_drive/Protocol_web_one_drive.java
+++ b/testar/resources/settings/web_one_drive/Protocol_web_one_drive.java
@@ -96,6 +96,7 @@ public class Protocol_web_one_drive extends DesktopProtocol {
 	 *      seconds until they have finished loading)
 	 * @return  a started SUT, ready to be tested.
 	 */
+	@Override
 	protected SUT startSystem() throws SystemStartException{
 
 		SUT sut = super.startSystem();
@@ -212,6 +213,7 @@ public class Protocol_web_one_drive extends DesktopProtocol {
 	 * state is erroneous and if so why.
 	 * @return  the current state of the SUT with attached oracle.
 	 */
+	@Override
 	protected State getState(SUT system) throws StateBuildException{
 
 		State state = super.getState(system);
@@ -231,6 +233,7 @@ public class Protocol_web_one_drive extends DesktopProtocol {
 	 * It examines the SUT's current state and returns an oracle verdict.
 	 * @return oracle verdict, which determines whether the state is erroneous and why.
 	 */
+	@Override
 	protected Verdict getVerdict(State state){
 
 		Verdict verdict = super.getVerdict(state);
@@ -308,6 +311,7 @@ public class Protocol_web_one_drive extends DesktopProtocol {
 	 * @param state the SUT's current state
 	 * @return  a set of actions
 	 */
+	@Override
 	protected Set<Action> deriveActions(SUT system, State state) throws ActionBuildException{
 
 		Set<Action> actions = super.deriveActions(system,state);

--- a/testar/src/org/fruit/monkey/DefaultProtocol.java
+++ b/testar/src/org/fruit/monkey/DefaultProtocol.java
@@ -932,13 +932,7 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 
 		while(mode() == Modes.Spy && system.isRunning()) {
 
-			//Instead of use getState(SUT system) method, build our own State into Spy Mode
-			//This will prevent issues with other protocols and reports
-			Assert.notNull(system);
-			State state = builder.apply(system);
-			CodingManager.buildIDs(state);
-			calculateZIndices(state);
-			setStateForClickFilterLayerProtocol(state);
+			State state = getState(system);
 
 			cv.begin(); Util.clear(cv);
 
@@ -1473,7 +1467,12 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 
 		CodingManager.buildIDs(state);
 		calculateZIndices(state);
+		
+		setStateForClickFilterLayerProtocol(state);
 
+		if(mode() == Modes.Spy)
+			return state;
+		
 		Verdict verdict = getVerdict(state);
 		state.set(Tags.OracleVerdict, verdict);
 
@@ -1492,7 +1491,7 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 			passSeverity = verdict.severity();
 			LogSerialiser.log("Detected warning: " + verdict + "\n", LogSerialiser.LogLevel.Critical);
 		}
-		setStateForClickFilterLayerProtocol(state);
+		
 		return state;
 	}
 

--- a/testar/src/org/fruit/monkey/SettingsDialog.java
+++ b/testar/src/org/fruit/monkey/SettingsDialog.java
@@ -70,7 +70,7 @@ import static org.fruit.monkey.dialog.ToolTipTexts.*;
 public class SettingsDialog extends JFrame implements Observer {
   private static final long serialVersionUID = 5156320008281200950L;
 
-  static final String TESTAR_VERSION = "2.1.3 (10-June-2019)";
+  static final String TESTAR_VERSION = "2.1.4 (16-July-2019)";
 
   private String settingsFile;
   private Settings settings;

--- a/testar/src/org/fruit/monkey/dialog/GeneralPanel.java
+++ b/testar/src/org/fruit/monkey/dialog/GeneralPanel.java
@@ -53,8 +53,6 @@ public class GeneralPanel extends JPanel {
   private JTextArea txtSutPath;
   private JSpinner spnNumSequences;
   private JSpinner spnSequenceLength;
-  private JSpinner esiSpinner;
-  private JComboBox<String> comboboxVerbosity;
   //private JCheckBox checkStopOnFault;
   private JComboBox<String> comboBoxProtocol;
   private JCheckBox compileCheckBox;
@@ -101,29 +99,14 @@ public class GeneralPanel extends JPanel {
     spnSequenceLength.setToolTipText(sequencesActionsTTT);
     add(spnSequenceLength);
 
-    esiSpinner = new JSpinner();
-    esiSpinner.setBounds(160, 237, 71, 25);
-    esiSpinner.setValue(10);
-    esiSpinner.setToolTipText(intervalTTT);
-    add(esiSpinner);
-
-    comboboxVerbosity = new JComboBox<>();
-    comboboxVerbosity.setModel(new DefaultComboBoxModel<>(
-        new String[]{"Critical", "Information", "Debug"}));
-    comboboxVerbosity.setSelectedIndex(1);
-    comboboxVerbosity.setBounds(160, 275, 107, 25);
-    comboboxVerbosity.setMaximumRowCount(3);
-    comboboxVerbosity.setToolTipText(loggingVerbosityTTT);
-    add(comboboxVerbosity);
-
     comboBoxProtocol = new JComboBox<>();
     comboBoxProtocol.setBounds(350, 161, 260, 25);
- //   String[] sutSettings = new File("./settings/")
     String[] sutSettings = new File(Main.settingsDir)
         .list((current, name) -> new File(current, name).isDirectory());
     Arrays.sort(sutSettings);
     comboBoxProtocol.setModel(new DefaultComboBoxModel<>(sutSettings));
     comboBoxProtocol.setMaximumRowCount(sutSettings.length > 16 ? 16 : sutSettings.length);
+    
     // Pass button click to settings dialog
     MyItemListener myItemListener = new MyItemListener();
     myItemListener.addObserver(settingsDialog);
@@ -185,16 +168,6 @@ public class GeneralPanel extends JPanel {
     lblNofSequences.setToolTipText(nofSequencesTTT);
     add(lblNofSequences);
 
-    JLabel lblSamplingInterval = new JLabel("Sampling interval:");
-    lblSamplingInterval.setBounds(10, 240, 100, 14);
-    lblSamplingInterval.setToolTipText(intervalTTT);
-    add(lblSamplingInterval);
-
-    JLabel lblLoggingVerbosity = new JLabel("Logging Verbosity:");
-    lblLoggingVerbosity.setBounds(10, 278, 120, 14);
-    lblLoggingVerbosity.setToolTipText(lblLoggingVerbosityTTT);
-    add(lblLoggingVerbosity);
-
     JLabel lblSequenceActions = new JLabel("Sequence actions:");
     lblSequenceActions.setBounds(10, 202, 148, 14);
     lblSequenceActions.setToolTipText(sequencesActionsTTT);
@@ -237,10 +210,8 @@ public class GeneralPanel extends JPanel {
     //checkStopOnFault.setSelected(settings.get(ConfigTags.StopGenerationOnFault));
     txtSutPath.setText(settings.get(ConfigTags.SUTConnectorValue));
     comboBoxProtocol.setSelectedItem(settings.get(ConfigTags.ProtocolClass).split("/")[0]);
-    esiSpinner.setValue(settings.get(ConfigTags.ExplorationSampleInterval));
     spnNumSequences.setValue(settings.get(ConfigTags.Sequences));
     spnSequenceLength.setValue(settings.get(ConfigTags.SequenceLength));
-    comboboxVerbosity.setSelectedIndex(settings.get(ConfigTags.LogLevel));
     compileCheckBox.setSelected(settings.get(ConfigTags.AlwaysCompile));
     applicationNameField.setText(settings.get(ConfigTags.ApplicationName));
     applicationVersionField.setText(settings.get(ConfigTags.ApplicationVersion));
@@ -256,9 +227,7 @@ public class GeneralPanel extends JPanel {
     settings.set(ConfigTags.SUTConnectorValue, txtSutPath.getText());
     //settings.set(ConfigTags.StopGenerationOnFault, checkStopOnFault.isSelected());
     settings.set(ConfigTags.SUTConnectorValue, txtSutPath.getText());
-    settings.set(ConfigTags.ExplorationSampleInterval, (Integer) esiSpinner.getValue());
     settings.set(ConfigTags.Sequences, (Integer) spnNumSequences.getValue());
-    settings.set(ConfigTags.LogLevel, comboboxVerbosity.getSelectedIndex());
     settings.set(ConfigTags.SequenceLength, (Integer) spnSequenceLength.getValue());
     settings.set(ConfigTags.AlwaysCompile, compileCheckBox.isSelected());
     settings.set(ConfigTags.ApplicationName, applicationNameField.getText());

--- a/testar/src/org/testar/protocols/DesktopProtocol.java
+++ b/testar/src/org/testar/protocols/DesktopProtocol.java
@@ -75,7 +75,11 @@ public class DesktopProtocol extends ClickFilterLayerProtocol {
      */
     @Override
     protected State getState(SUT system) throws StateBuildException {
-        latestState = super.getState(system);
+        //Spy mode didn't use the html report
+    	if(mode() == Modes.Spy)
+        	return super.getState(system);
+    	
+    	latestState = super.getState(system);
         //adding state to the HTML sequence report:
         htmlReport.addState(latestState);
         return latestState;


### PR DESCRIPTION
Use the getState method again into Spy Mode.
We changed it with the idea of preventing future problems with the different protocols. (Ex. html report)
But we are offering different visualizations to the end users.

In the web_generic protocol the user can't use properly the "browser_toolbar_filter" with the Spy Mode but it will works with Generate mode. It's confusing.