### PR TITLE
Fixed mouse interaction for webdriver protocol.

### DIFF
--- a/testar/resources/settings/webdriver_generic/test.settings
+++ b/testar/resources/settings/webdriver_generic/test.settings
@@ -108,6 +108,21 @@ GraphDBUser =
 GraphDBPassword =
 
 #################################################################
+# Override display scale
+#
+# Overrides the displayscale obtained from the system. 
+# Can solve problems when the mouse clicks are not aligned with 
+# the elements on the screen. This can easily be deteced when
+# running the spy mode. FOr example hover over a text element and
+# the popup window should appear with information about the 
+# element, if the popup window is not shown or when the mouse is
+# located somewhere else you can try to override the displayscale
+# Values should be provided as doubles (1.5). 
+#################################################################
+
+OverrideWebDriverDisplayScale = 
+
+#################################################################
 # Other more advanced settings
 #################################################################
 

--- a/testar/resources/settings/webdriver_generic/test.settings
+++ b/testar/resources/settings/webdriver_generic/test.settings
@@ -112,8 +112,8 @@ GraphDBPassword =
 #
 # Overrides the displayscale obtained from the system. 
 # Can solve problems when the mouse clicks are not aligned with 
-# the elements on the screen. This can easily be deteced when
-# running the spy mode. FOr example hover over a text element and
+# the elements on the screen. This can easily be detected when
+# running the spy mode. For example hover over a text element and
 # the popup window should appear with information about the 
 # element, if the popup window is not shown or when the mouse is
 # located somewhere else you can try to override the displayscale

--- a/testar/resources/settings/webdriver_gwt/test.settings
+++ b/testar/resources/settings/webdriver_gwt/test.settings
@@ -108,6 +108,21 @@ GraphDBUser =
 GraphDBPassword =
 
 #################################################################
+# Override display scale
+#
+# Overrides the displayscale obtained from the system. 
+# Can solve problems when the mouse clicks are not aligned with 
+# the elements on the screen. This can easily be deteced when
+# running the spy mode. FOr example hover over a text element and
+# the popup window should appear with information about the 
+# element, if the popup window is not shown or when the mouse is
+# located somewhere else you can try to override the displayscale
+# Values should be provided as doubles (1.5). 
+#################################################################
+
+OverrideWebDriverDisplayScale = 
+
+#################################################################
 # Other more advanced settings
 #################################################################
 

--- a/testar/resources/settings/webdriver_gwt/test.settings
+++ b/testar/resources/settings/webdriver_gwt/test.settings
@@ -112,8 +112,8 @@ GraphDBPassword =
 #
 # Overrides the displayscale obtained from the system. 
 # Can solve problems when the mouse clicks are not aligned with 
-# the elements on the screen. This can easily be deteced when
-# running the spy mode. FOr example hover over a text element and
+# the elements on the screen. This can easily be detected when
+# running the spy mode. For example hover over a text element and
 # the popup window should appear with information about the 
 # element, if the popup window is not shown or when the mouse is
 # located somewhere else you can try to override the displayscale

--- a/testar/resources/settings/webdriver_spy_custom/test.settings
+++ b/testar/resources/settings/webdriver_spy_custom/test.settings
@@ -108,6 +108,21 @@ GraphDBUser =
 GraphDBPassword =
 
 #################################################################
+# Override display scale
+#
+# Overrides the displayscale obtained from the system. 
+# Can solve problems when the mouse clicks are not aligned with 
+# the elements on the screen. This can easily be deteced when
+# running the spy mode. FOr example hover over a text element and
+# the popup window should appear with information about the 
+# element, if the popup window is not shown or when the mouse is
+# located somewhere else you can try to override the displayscale
+# Values should be provided as doubles (1.5). 
+#################################################################
+
+OverrideWebDriverDisplayScale = 
+
+#################################################################
 # Other more advanced settings
 #################################################################
 

--- a/testar/resources/settings/webdriver_spy_custom/test.settings
+++ b/testar/resources/settings/webdriver_spy_custom/test.settings
@@ -112,8 +112,8 @@ GraphDBPassword =
 #
 # Overrides the displayscale obtained from the system. 
 # Can solve problems when the mouse clicks are not aligned with 
-# the elements on the screen. This can easily be deteced when
-# running the spy mode. FOr example hover over a text element and
+# the elements on the screen. This can easily be detected when
+# running the spy mode. For example hover over a text element and
 # the popup window should appear with information about the 
 # element, if the popup window is not shown or when the mouse is
 # located somewhere else you can try to override the displayscale

--- a/testar/resources/settings/webdriver_statemodel/test.settings
+++ b/testar/resources/settings/webdriver_statemodel/test.settings
@@ -132,8 +132,8 @@ AbstractStateAttributes = WidgetControlType
 #
 # Overrides the displayscale obtained from the system. 
 # Can solve problems when the mouse clicks are not aligned with 
-# the elements on the screen. This can easily be deteced when
-# running the spy mode. FOr example hover over a text element and
+# the elements on the screen. This can easily be detected when
+# running the spy mode. For example hover over a text element and
 # the popup window should appear with information about the 
 # element, if the popup window is not shown or when the mouse is
 # located somewhere else you can try to override the displayscale

--- a/testar/resources/settings/webdriver_statemodel/test.settings
+++ b/testar/resources/settings/webdriver_statemodel/test.settings
@@ -128,6 +128,21 @@ DataStoreMode = instant
 AbstractStateAttributes = WidgetControlType
 
 #################################################################
+# Override display scale
+#
+# Overrides the displayscale obtained from the system. 
+# Can solve problems when the mouse clicks are not aligned with 
+# the elements on the screen. This can easily be deteced when
+# running the spy mode. FOr example hover over a text element and
+# the popup window should appear with information about the 
+# element, if the popup window is not shown or when the mouse is
+# located somewhere else you can try to override the displayscale
+# Values should be provided as doubles (1.5). 
+#################################################################
+
+OverrideWebDriverDisplayScale = 
+
+#################################################################
 # Other more advanced settings
 #################################################################
 

--- a/testar/src/org/fruit/monkey/ConfigTags.java
+++ b/testar/src/org/fruit/monkey/ConfigTags.java
@@ -126,4 +126,8 @@ public final class ConfigTags {
   public static final Tag<Boolean> ProcessListenerEnabled = Tag.from("ProcessListenerEnabled", Boolean.class);
   public static final Tag<String> SuspiciousProcessOutput = Tag.from("SuspiciousProcessOutput", String.class);
   public static final Tag<String> ProcessLogs = Tag.from("ProcessLogs", String.class);
+
+  // Note: Defined the tag as string on purpose so we can leave the default value empty in the pre defined settings.
+  public static final Tag<String> OverrideWebDriverDisplayScale = Tag.from("OverrideWebDriverDisplayScale", String.class);
+
 }

--- a/testar/src/org/fruit/monkey/ConfigTags.java
+++ b/testar/src/org/fruit/monkey/ConfigTags.java
@@ -1,6 +1,7 @@
 /***************************************************************************************************
 *
-* Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018 Universitat Politecnica de Valencia - www.upv.es
+* Copyright (c) 2013 - 2020 Universitat Politecnica de Valencia - www.upv.es
+* Copyright (c) 2018 - 2020 Open Universiteit - www.ou.nl
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -28,15 +29,11 @@
 *******************************************************************************************************/
 
 
-/**
- * @author Sebastian Bauersfeld
- */
 package org.fruit.monkey;
 
 import org.fruit.Pair;
 import org.fruit.alayer.Tag;
 
-import java.lang.reflect.Array;
 import java.util.List;
 
 public final class ConfigTags {
@@ -77,7 +74,6 @@ public final class ConfigTags {
   public static final Tag<Double> TimeToFreeze = Tag.from("TimeToFreeze", Double.class);
   public static final Tag<Boolean> ShowSettingsAfterTest = Tag.from("ShowSettingsAfterTest", Boolean.class);
 
-  // begin by urueda
   public static final Tag<String> SUTConnector = Tag.from("SUTConnector", String.class);
   public static final Tag<String> TestGenerator = Tag.from("TestGenerator", String.class);
   public static final Tag<Double> MaxReward = Tag.from("MaxReward", Double.class);
@@ -97,7 +93,7 @@ public final class ConfigTags {
   public static final Tag<Boolean> AccessBridgeEnabled = Tag.from("AccessBridgeEnabled", Boolean.class);
   public static final Tag<String> SUTProcesses = Tag.from("SUTProcesses", String.class); // Shift+0 shortcut to debug (STDOUT) windows' process names
 
-  // begin by florendegier
+  // graph db config tags
   public static final Tag<Boolean> GraphDBEnabled = Tag.from("GraphDBEnabled", Boolean.class);
   public static final Tag<String> GraphDBUrl = Tag.from("GraphDBUrl", String.class);
   public static final Tag<String> GraphDBUser = Tag.from("GraphDBUser", String.class);

--- a/testar/src/org/fruit/monkey/Main.java
+++ b/testar/src/org/fruit/monkey/Main.java
@@ -465,6 +465,7 @@ public class Main {
 			defaults.add(Pair.from(ProcessListenerEnabled, false));
 			defaults.add(Pair.from(SuspiciousProcessOutput, "(?!x)x"));
 			defaults.add(Pair.from(ProcessLogs, ".*.*"));
+			defaults.add(Pair.from(OverrideWebDriverDisplayScale, ""));
 
 			defaults.add(Pair.from(AbstractStateAttributes, new ArrayList<String>() {
 				{

--- a/testar/src/org/fruit/monkey/Main.java
+++ b/testar/src/org/fruit/monkey/Main.java
@@ -1,7 +1,7 @@
 /***************************************************************************************************
  *
- * Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019 Universitat Politecnica de Valencia - www.upv.es
- * Copyright (c) 2018, 2019 Open Universiteit - www.ou.nl
+ * Copyright (c) 2013 - 2020 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2018 - 2020 Open Universiteit - www.ou.nl
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -30,9 +30,6 @@
 
 
 
-/**
- *  @author Sebastian Bauersfeld
- */
 package org.fruit.monkey;
 
 import es.upv.staq.testar.CodingManager;
@@ -43,21 +40,15 @@ import es.upv.staq.testar.serialisation.LogSerialiser;
 import es.upv.staq.testar.serialisation.ScreenshotSerialiser;
 import es.upv.staq.testar.serialisation.TestSerialiser;
 import org.fruit.*;
-import org.fruit.alayer.State;
 import org.fruit.alayer.Tag;
 
 import javax.swing.*;
 import java.io.*;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.security.cert.CollectionCertStoreParameters;
 import java.util.*;
-import java.util.stream.Collectors;
-
-import org.fruit.alayer.windows.UIATags;
 import org.fruit.alayer.windows.Windows10;
 
-import static java.lang.System.exit;
 import static org.fruit.monkey.ConfigTags.*;
 
 public class Main {

--- a/testar/src/org/fruit/monkey/Settings.java
+++ b/testar/src/org/fruit/monkey/Settings.java
@@ -1,6 +1,7 @@
 /***************************************************************************************************
 *
-* Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018 Universitat Politecnica de Valencia - www.upv.es
+* Copyright (c) 2013 - 2020 Universitat Politecnica de Valencia - www.upv.es
+* Copyright (c) 2018 - 2020 Open Universiteit - www.ou.nl
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -44,7 +45,6 @@ import java.io.StringReader;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import es.upv.staq.testar.CodingManager;
 import es.upv.staq.testar.StateManagementTags;
 import org.fruit.Assert;
 import org.fruit.FruitException;
@@ -281,15 +281,15 @@ public class Settings extends TaggableBase implements Serializable {
 					+"#\n"
 					+"# Indicate how you want to connect to the SUT:\n"
 					+"#\n"
-					+"# SUTCONNECTOR = COMMAND_LINE, SUTCONNECTORValue property must be a command line that\n"
+					+"# SUTCONNECTOR = COMMAND_LINE, SUTConnectorValue property must be a command line that\n"
 					+"# starts the SUT.\n"
 					+"# It should work from a Command Prompt terminal window (e.g. java - jar SUTs/calc.jar ).\n"
 					+"# For web applications, follow the next format: web_browser_path SUT_URL.\n"
 					+"#\n"
-					+"# SUTCONNECTOR = SUT_WINDOW_TITLE, then SUTCONNECTORValue property must be the title displayed\n"
+					+"# SUTCONNECTOR = SUT_WINDOW_TITLE, then SUTConnectorValue property must be the title displayed\n"
 					+"# in the SUT main window. The SUT must be manually started and closed.\n"
 					+"#\n"
-					+"# SUTCONNECTOR = SUT_PROCESS_NAME: SUTCONNECTORValue property must be the process name of the SUT.\n"
+					+"# SUTCONNECTOR = SUT_PROCESS_NAME: SUTConnectorValue property must be the process name of the SUT.\n"
 					+"# The SUT must be manually started and closed.\n"
 					+"#################################################################\n"
 					+"SUTConnector = " + Util.lineSep()
@@ -406,8 +406,23 @@ public class Settings extends TaggableBase implements Serializable {
 					+"#\n"
 					+"# Specify the widget attributes that you wish to use in constructing\n"
 					+"# the widget and state hash strings. Use a comma separated list.\n"
-                    +"#################################################################\n"
-			        +"AbstractStateAttributes =" + Util.lineSep()
+					+"#################################################################\n"
+					+"AbstractStateAttributes =" + Util.lineSep()
+					+"\n"
+					+"#################################################################\n"
+					+"# Override display scale\n"
+					+"#\n"
+					+"# Overrides the displayscale obtained from the system.\n"
+					+"# Can solve problems when the mouse clicks are not aligned with\n"
+					+"# the elements on the screen. This can easily be detected when\n"
+					+"# running the spy mode. For example hover over a text element and\n"
+					+"# the popup window should appear with information about the\n"
+					+"# element, if the popup window is not shown or when the mouse is\n"
+					+"# located somewhere else you can try to override the displayscale\n"
+					+"# Values should be provided as doubles (1.5).\n"
+					+"#################################################################\n"
+					+"\n"
+					+"OverrideWebDriverDisplayScale =" + Util.lineSep()
 					+"\n"
 					+"#################################################################\n"
 					+"# Other more advanced settings\n"

--- a/testar/src/org/fruit/monkey/SettingsDialog.java
+++ b/testar/src/org/fruit/monkey/SettingsDialog.java
@@ -1,7 +1,7 @@
 /***************************************************************************************************
 *
-* Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019 Universitat Politecnica de Valencia - www.upv.es
-* Copyright (c) 2018, 2019 Open Universiteit - www.ou.nl
+* Copyright (c) 2013 - 2020 Universitat Politecnica de Valencia - www.upv.es
+* Copyright (c) 2018 - 2020 Open Universiteit - www.ou.nl
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -35,7 +35,6 @@
 package org.fruit.monkey;
 
 import es.upv.staq.testar.serialisation.LogSerialiser;
-import nl.ou.testar.GraphDBPanel;
 import nl.ou.testar.StateModel.Settings.StateModelPanel;
 import org.fruit.Util;
 import org.fruit.monkey.dialog.*;
@@ -70,7 +69,7 @@ import static org.fruit.monkey.dialog.ToolTipTexts.*;
 public class SettingsDialog extends JFrame implements Observer {
   private static final long serialVersionUID = 5156320008281200950L;
 
-  static final String TESTAR_VERSION = "2.2.4 (19-Feb-2020)";
+  static final String TESTAR_VERSION = "2.2.5 (16-Mar-2020)";
 
 
   private String settingsFile;

--- a/testar/src/org/fruit/monkey/dialog/GeneralPanel.java
+++ b/testar/src/org/fruit/monkey/dialog/GeneralPanel.java
@@ -1,7 +1,7 @@
 /***************************************************************************************************
 *
-* Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019 Universitat Politecnica de Valencia - www.upv.es
-* Copyright (c) 2018, 2019 Open Universiteit - www.ou.nl
+* Copyright (c) 2013 - 2020 Universitat Politecnica de Valencia - www.upv.es
+* Copyright (c) 2018 - 2020 Open Universiteit - www.ou.nl
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -31,7 +31,6 @@
 
 package org.fruit.monkey.dialog;
 
-import nl.ou.testar.StateModel.Persistence.OrientDB.Entity.Config;
 import org.fruit.monkey.*;
 
 import javax.swing.*;
@@ -134,20 +133,26 @@ public class GeneralPanel extends JPanel implements Observer {
     add(checkStopOnFault);*/
     
     labelAppName.setBounds(330, 242, 150, 27);
+    labelAppName.setToolTipText(applicationNameTTT);
     add(labelAppName);
     applicationNameField.setBounds(480, 242, 125, 27);
+    applicationNameField.setToolTipText(applicationNameTTT);
     add(applicationNameField);
 
     labelAppVersion.setBounds(330, 280, 150, 27);
+    labelAppVersion.setToolTipText(applicationVersionTTT);
     add(labelAppVersion);
     applicationVersionField.setBounds(480, 280, 125, 27);
+    applicationVersionField.setToolTipText(applicationVersionTTT);
     add(applicationVersionField);
 
     // Hide the override webdriver display scale fields by default, only show them when a webdriver protocol is selected.
     setOverrideWebDriverDisplayScaleVisibility(false);
     labelOverrideWebDriverDisplayScale.setBounds(330, 320, 150, 27);
+    labelOverrideWebDriverDisplayScale.setToolTipText(overrideWebDriverDisplayScaleTTT);
     add(labelOverrideWebDriverDisplayScale);
     overrideWebDriverDisplayScaleField.setBounds(480, 320, 125, 27);
+    overrideWebDriverDisplayScaleField.setToolTipText(overrideWebDriverDisplayScaleTTT);
     add(overrideWebDriverDisplayScaleField);
   }
 

--- a/testar/src/org/fruit/monkey/dialog/GeneralPanel.java
+++ b/testar/src/org/fruit/monkey/dialog/GeneralPanel.java
@@ -31,6 +31,7 @@
 
 package org.fruit.monkey.dialog;
 
+import nl.ou.testar.StateModel.Persistence.OrientDB.Entity.Config;
 import org.fruit.monkey.*;
 
 import javax.swing.*;
@@ -41,10 +42,11 @@ import java.awt.event.ItemListener;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Observable;
+import java.util.Observer;
 
 import static org.fruit.monkey.dialog.ToolTipTexts.*;
 
-public class GeneralPanel extends JPanel {
+public class GeneralPanel extends JPanel implements Observer {
 
   private static final long serialVersionUID = -7401834140061189752L;
 
@@ -59,8 +61,13 @@ public class GeneralPanel extends JPanel {
   
   private JLabel labelAppName = new JLabel("Application name");
   private JLabel labelAppVersion = new JLabel("Application version");
+
   private JTextField applicationNameField = new JTextField();
   private JTextField applicationVersionField = new JTextField();
+
+  private JLabel labelOverrideWebDriverDisplayScale = new JLabel("Override display scale");
+  private JTextField overrideWebDriverDisplayScaleField = new JTextField();
+
 
   public GeneralPanel(SettingsDialog settingsDialog) {
     setLayout(null);
@@ -111,6 +118,7 @@ public class GeneralPanel extends JPanel {
     // Pass button click to settings dialog
     MyItemListener myItemListener = new MyItemListener();
     myItemListener.addObserver(settingsDialog);
+    myItemListener.addObserver(this);
     comboBoxProtocol.addItemListener(myItemListener);
     comboBoxProtocol.setToolTipText(comboBoxProtocolTTT);
     add(comboBoxProtocol);
@@ -134,6 +142,24 @@ public class GeneralPanel extends JPanel {
     add(labelAppVersion);
     applicationVersionField.setBounds(480, 280, 125, 27);
     add(applicationVersionField);
+
+    // Hide the override webdriver display scale fields by default, only show them when a webdriver protocol is selected.
+    setOverrideWebDriverDisplayScaleVisibility(false);
+    labelOverrideWebDriverDisplayScale.setBounds(330, 320, 150, 27);
+    add(labelOverrideWebDriverDisplayScale);
+    overrideWebDriverDisplayScaleField.setBounds(480, 320, 125, 27);
+    add(overrideWebDriverDisplayScaleField);
+  }
+
+  private void setOverrideWebDriverDisplayScaleVisibility(boolean isVisible){
+    labelOverrideWebDriverDisplayScale.setVisible(isVisible);
+    overrideWebDriverDisplayScaleField.setVisible(isVisible);
+  }
+
+  @Override
+  public void update(Observable o, Object arg) {
+    boolean showWidgets = arg.toString().contains("webdriver");
+    setOverrideWebDriverDisplayScaleVisibility(showWidgets);
   }
 
   private void addGeneralControlsLocal() {
@@ -225,6 +251,7 @@ public class GeneralPanel extends JPanel {
     compileCheckBox.setSelected(settings.get(ConfigTags.AlwaysCompile));
     applicationNameField.setText(settings.get(ConfigTags.ApplicationName));
     applicationVersionField.setText(settings.get(ConfigTags.ApplicationVersion));
+    overrideWebDriverDisplayScaleField.setText(settings.get(ConfigTags.OverrideWebDriverDisplayScale));
   }
 
   /**
@@ -242,6 +269,7 @@ public class GeneralPanel extends JPanel {
     settings.set(ConfigTags.AlwaysCompile, compileCheckBox.isSelected());
     settings.set(ConfigTags.ApplicationName, applicationNameField.getText());
     settings.set(ConfigTags.ApplicationVersion, applicationVersionField.getText());
+    settings.set(ConfigTags.OverrideWebDriverDisplayScale, overrideWebDriverDisplayScaleField.getText());
   }
 
   public class MyItemListener extends Observable implements ItemListener {

--- a/testar/src/org/fruit/monkey/dialog/ToolTipTexts.java
+++ b/testar/src/org/fruit/monkey/dialog/ToolTipTexts.java
@@ -1,6 +1,7 @@
 /***************************************************************************************************
 *
-* Copyright (c) 2013, 2014, 2015, 2016, 2017 Universitat Politecnica de Valencia - www.upv.es
+* Copyright (c) 2013 - 2020 Universitat Politecnica de Valencia - www.upv.es
+* Copyright (c) 2018 - 2020 Open Universiteit - www.ou.nl
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -72,6 +73,27 @@ public class ToolTipTexts {
   public static String intervalTTT = "Set the sampling interval";
   public static String comboBoxProtocolTTT = "Select the protocol you want to use from the dropdown list";
   public static String btnSelectSUTTTT = "Select the path to the SUT by navigating to it";
+  public static String applicationNameTTT = "<html>" +
+		  "Use a name identifier to represent the current application.<br>" + 
+		  "This will be used to create the output structure reports and for State Model purposes.<br>" +
+		  "Example: Notepad" +
+		  "</html>";
+  public static String applicationVersionTTT = "<html>" +
+		  "Use a version identifier to represent the current application.<br>" + 
+		  "This will be used to create the output structure reports and for State Model purposes.<br>" + 
+		  "Example: 1.0.0" +
+		  "</html>";
+  public static String overrideWebDriverDisplayScaleTTT = "<html>" +
+		  "NOTE: KEEP this field EMPTY if the coordinates of <br>" +
+		  "the widgets and actions are detected correctly with SPY and GENERATE mode.<br><br>" + 
+		  "Overrides the displayscale obtained from the system.<br>" + 
+		  "Can solve problems when the mouse clicks are not aligned with the elements on the screen.<br>" + 
+		  "This can easily be detected when running the spy mode.<br>" + 
+		  "For example hover over a text element and the popup window should appear with information<br>" + 
+		  "about the element, if the popup window is not shown or when the mouse is<br>" + 
+		  "located somewhere else you can try to override the displayscale<br>" + 
+		  "Values should be provided as doubles (1.5)." +
+		  "</html>";
 
   // TTTs for the walker tab
   public static String testGeneratorTTT = "Determines how the IU actions are selected during tests";

--- a/testar/src/org/testar/protocols/WebdriverProtocol.java
+++ b/testar/src/org/testar/protocols/WebdriverProtocol.java
@@ -1,7 +1,7 @@
 /***************************************************************************************************
  *
- * Copyright (c) 2019 Universitat Politecnica de Valencia - www.upv.es
- * Copyright (c) 2019 Open Universiteit - www.ou.nl
+ * Copyright (c) 2019, 2020 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2019, 2020 Open Universiteit - www.ou.nl
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -52,12 +52,10 @@ import org.fruit.alayer.exceptions.StateBuildException;
 import org.fruit.alayer.exceptions.SystemStartException;
 import org.fruit.alayer.webdriver.WdDriver;
 import org.fruit.alayer.webdriver.WdElement;
-import org.fruit.alayer.webdriver.WdMouse;
 import org.fruit.alayer.webdriver.WdWidget;
 import org.fruit.alayer.windows.WinProcess;
 import org.fruit.alayer.windows.Windows;
 import org.fruit.monkey.ConfigTags;
-import org.fruit.monkey.Settings;
 import org.testar.OutputStructure;
 
 import es.upv.staq.testar.NativeLinker;
@@ -135,7 +133,7 @@ public class WebdriverProtocol extends ClickFilterLayerProtocol {
 		double displayScale = Environment.getInstance().getDisplayScale(sut.get(Tags.HWND, (long)0));
 
 		// If the user has specified a scale override the display scale obtained from the system.
-		String overrideDisplayScaleAsString = settings().get(ConfigTags.OverrideWebDriverDisplayScale);
+		String overrideDisplayScaleAsString = settings().get(ConfigTags.OverrideWebDriverDisplayScale, "");
 		if (!overrideDisplayScaleAsString.isEmpty()) {
 			try {
 				double webDriverDisplayScaleOverride = Double.parseDouble(overrideDisplayScaleAsString);

--- a/testar/src/org/testar/protocols/WebdriverProtocol.java
+++ b/testar/src/org/testar/protocols/WebdriverProtocol.java
@@ -119,6 +119,8 @@ public class WebdriverProtocol extends ClickFilterLayerProtocol {
 
         // See remarks in WdMouse
         mouse = sut.get(Tags.StandardMouse);
+        mouse.setCursorDisplayScale(displayScale);
+
     	return sut;
     }
 

--- a/testar/src/org/testar/protocols/WebdriverProtocol.java
+++ b/testar/src/org/testar/protocols/WebdriverProtocol.java
@@ -119,8 +119,6 @@ public class WebdriverProtocol extends ClickFilterLayerProtocol {
 
         // See remarks in WdMouse
         mouse = sut.get(Tags.StandardMouse);
-        mouse.setCursorDisplayScale(displayScale);
-
     	return sut;
     }
 

--- a/webdriver/src/org/fruit/alayer/webdriver/WdMouse.java
+++ b/webdriver/src/org/fruit/alayer/webdriver/WdMouse.java
@@ -55,8 +55,6 @@ public class WdMouse implements Mouse {
 
   private final Robot robot;
   
-  private double displayScale;
-
   public static WdMouse build() throws FruitException {
     return new WdMouse();
   }
@@ -64,16 +62,13 @@ public class WdMouse implements Mouse {
   private WdMouse() throws FruitException {
     try {
       robot = new Robot();
-      this.displayScale = 1.0;
     }
     catch (AWTException awte) {
       throw new FruitException(awte);
     }
   }
   
-  public void setCursorDisplayScale(double displayScale) {
-	  this.displayScale = displayScale;
-  }
+  public void setCursorDisplayScale(double displayScale) {}
 
   public String toString() {
     return "WD Mouse";
@@ -97,9 +92,6 @@ public class WdMouse implements Mouse {
     
     canvasX += CanvasDimensions.getCanvasX();
     canvasY += CanvasDimensions.getCanvasY();
-    
-    canvasX = canvasX * displayScale;
-    canvasY = canvasY * displayScale;
 
     robot.mouseMove((int)canvasX, (int)canvasY);
   }
@@ -111,8 +103,9 @@ public class WdMouse implements Mouse {
     }
     java.awt.Point p = info.getLocation();
 
-    int viewportX = (int) ((p.x/ displayScale) - CanvasDimensions.getCanvasX());
-    int viewportY = (int) ((p.y/ displayScale) - CanvasDimensions.getCanvasY());
+    int viewportX = p.x - CanvasDimensions.getCanvasX();
+    int viewportY = p.y - CanvasDimensions.getCanvasY();
+
     return org.fruit.alayer.Point.from(viewportX, viewportY);
   }
 }

--- a/webdriver/src/org/fruit/alayer/webdriver/WdMouse.java
+++ b/webdriver/src/org/fruit/alayer/webdriver/WdMouse.java
@@ -55,6 +55,8 @@ public class WdMouse implements Mouse {
 
   private final Robot robot;
   
+  private double displayScale;
+
   public static WdMouse build() throws FruitException {
     return new WdMouse();
   }
@@ -62,13 +64,16 @@ public class WdMouse implements Mouse {
   private WdMouse() throws FruitException {
     try {
       robot = new Robot();
+      this.displayScale = 1.0;
     }
     catch (AWTException awte) {
       throw new FruitException(awte);
     }
   }
   
-  public void setCursorDisplayScale(double displayScale) {}
+  public void setCursorDisplayScale(double displayScale) {
+	  this.displayScale = displayScale;
+  }
 
   public String toString() {
     return "WD Mouse";
@@ -92,6 +97,9 @@ public class WdMouse implements Mouse {
     
     canvasX += CanvasDimensions.getCanvasX();
     canvasY += CanvasDimensions.getCanvasY();
+    
+    canvasX = canvasX * displayScale;
+    canvasY = canvasY * displayScale;
 
     robot.mouseMove((int)canvasX, (int)canvasY);
   }
@@ -103,9 +111,8 @@ public class WdMouse implements Mouse {
     }
     java.awt.Point p = info.getLocation();
 
-    int viewportX = p.x - CanvasDimensions.getCanvasX();
-    int viewportY = p.y - CanvasDimensions.getCanvasY();
-
+    int viewportX = (int) ((p.x/ displayScale) - CanvasDimensions.getCanvasX());
+    int viewportY = (int) ((p.y/ displayScale) - CanvasDimensions.getCanvasY());
     return org.fruit.alayer.Point.from(viewportX, viewportY);
   }
 }


### PR DESCRIPTION
I noticed that with the latest merge the mousce actions are not executed correctly when using the webdriver protocol.
Reverted the change that applied the displayscale to the mouse coordinate while using the webdriver protocol. Tested on macbook with different display scales and blurry on/off functions. Needs te be tested on multiple systems including a setup with an additional monitor.