### PR TITLE
Add gradle workflow to test TESTAR

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,56 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: TESTAR CI - build with Gradle
+
+on:
+  push:
+    branches: [ master, master_gradle_workflow ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build TESTAR with Gradle
+      run: ./gradlew build
+    - name: Prepare installed distribution of TESTAR with Gradle
+      run: ./gradlew installDist
+    - name: Run desktop_generic protocol with TESTAR using COMMAND_LINE
+      run: ./gradlew runTestDesktopGenericCommandLineOk
+    - name: Save runTestDesktopGenericCommandLineOk HTML report artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: runTestDesktopGenericCommandLineOk-artifact
+        path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_ok
+    - name: Run desktop_generic protocol that contains SuspiciousTitle with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSuspiciousTitle
+    - name: Save runTestDesktopGenericCommandLineSuspiciousTitle HTML report artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: runTestDesktopGenericCommandLineSuspiciousTitle-artifact
+        path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_command_and_suspicious
+    - name: Run desktop_generic protocol but connect using SUT_PROCESS_NAME and detect SuspiciousTitle
+      run: ./gradlew runTestDesktopGenericProcessNameSuspiciousTitle
+    - name: Save runTestDesktopGenericProcessNameSuspiciousTitle HTML report artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: runTestDesktopGenericProcessNameSuspiciousTitle-artifact
+        path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_process_and_suspicious
+    - name: Run desktop_generic protocol but connect using SUT_WINDOW_TITLE and detect SuspiciousTitle
+      run: ./gradlew runTestDesktopGenericTitleNameSuspiciousTitle
+    - name: Save runTestDesktopGenericTitleNameSuspiciousTitle HTML report artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: runTestDesktopGenericTitleNameSuspiciousTitle-artifact
+        path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_title_and_suspicious

--- a/native/src/es/upv/staq/testar/NativeLinker.java
+++ b/native/src/es/upv/staq/testar/NativeLinker.java
@@ -1,7 +1,7 @@
 /***************************************************************************************************
  *
- * Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019 Universitat Politecnica de Valencia - www.upv.es
- * Copyright (c) 2019 Open Universiteit - www.ou.nl
+ * Copyright (c) 2013 - 2020 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2018 - 2020 Open Universiteit - www.ou.nl
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -100,20 +100,26 @@ public class NativeLinker {
 	 * @param SUTProcesses A regex of the set of processes that conform the SUT.
 	 * @return A StateBuilder instance.
 	 */
-	public static StateBuilder getNativeStateBuilder(Double timeToFreeze,
-			boolean accessBridgeEnabled,
-			String SUTProcesses){
-		if (PLATFORM_OS.contains(OperatingSystems.WEBDRIVER))
+	public static StateBuilder getNativeStateBuilder(Double timeToFreeze, boolean accessBridgeEnabled, String SUTProcesses) {
+		if (PLATFORM_OS.contains(OperatingSystems.WEBDRIVER)) {
 			return new WdStateBuilder(timeToFreeze);
+		}
 		if (PLATFORM_OS.contains(OperatingSystems.WINDOWS)) {
-			if (PLATFORM_OS.contains(OperatingSystems.WINDOWS_7))
+			if (PLATFORM_OS.contains(OperatingSystems.WINDOWS_7)) {
 				return new UIAStateBuilder(timeToFreeze, accessBridgeEnabled, SUTProcesses);
+			}
 			else if (PLATFORM_OS.contains(OperatingSystems.WINDOWS_10)) {
 				// TODO: a win10 state builder might make use of the new CUI8 Automation object.
 				return new UIAStateBuilder(timeToFreeze, accessBridgeEnabled, SUTProcesses);
 			}
-		} else if (PLATFORM_OS.contains(OperatingSystems.UNIX))
+			else {
+				System.out.println("TESTAR detected OS: " + osName + " and this is not yet full supported. If the detected OS is wrong, please contact the TESTAR team at info@testar.org.");
+				return new UIAStateBuilder(timeToFreeze, accessBridgeEnabled, SUTProcesses);
+			}
+		} else if (PLATFORM_OS.contains(OperatingSystems.UNIX)) {
 			return new AtSpiStateBuilder(timeToFreeze);
+		}
+		
 		System.out.println("TESTAR detected OS: " + osName + " and this is not yet supported. If the detected OS is wrong, please contact the TESTAR team at info@testar.org. Exiting with Exception.");
 		throw new UnsupportedPlatformException();
 	}
@@ -144,20 +150,30 @@ public class NativeLinker {
 	 * @param executableCommand The application/ process/ command that will be run.
 	 * @return A handle to the process in a SUT object.
 	 */
-	public static SUT getNativeSUT(String executableCommand, boolean ProcessListenerEnabled){
-		if (PLATFORM_OS.contains(OperatingSystems.WEBDRIVER))
+	public static SUT getNativeSUT(String executableCommand, boolean ProcessListenerEnabled) {
+		if (PLATFORM_OS.contains(OperatingSystems.WEBDRIVER)) {
 			return WdDriver.fromExecutable(executableCommand);
+		}
 		if (PLATFORM_OS.contains(OperatingSystems.WINDOWS)) {
-			if (PLATFORM_OS.contains(OperatingSystems.WINDOWS_7))
+			if (PLATFORM_OS.contains(OperatingSystems.WINDOWS_7)) {
 				return WinProcess.fromExecutable(executableCommand, ProcessListenerEnabled);
-			else if (PLATFORM_OS.contains(OperatingSystems.WINDOWS_10)) {
-				if (executableCommand.toLowerCase().contains(".exe") || executableCommand.contains(".jar"))
-					return WinProcess.fromExecutable(executableCommand, ProcessListenerEnabled);
-				else
-					return WinProcess.fromExecutableUwp(executableCommand);
 			}
-		} else if (PLATFORM_OS.contains(OperatingSystems.UNIX))
+			else if (PLATFORM_OS.contains(OperatingSystems.WINDOWS_10)) {
+				if (executableCommand.toLowerCase().contains(".exe") || executableCommand.contains(".jar")) {
+					return WinProcess.fromExecutable(executableCommand, ProcessListenerEnabled);
+				}
+				else {
+					return WinProcess.fromExecutableUwp(executableCommand);
+				}
+			}
+			else {
+				System.out.println("TESTAR detected OS: " + osName + " and this is not yet full supported.");
+				return WinProcess.fromExecutable(executableCommand, ProcessListenerEnabled);
+			}
+		}
+		else if (PLATFORM_OS.contains(OperatingSystems.UNIX)) {
 			return LinuxProcess.fromExecutable(executableCommand);
+		}
 		throw new UnsupportedPlatformException();
 	}
 

--- a/testar/build.gradle
+++ b/testar/build.gradle
@@ -84,6 +84,7 @@ dependencies {
     compile group: 'org.eclipse.jetty', name: 'jetty-annotations', version: '9.4.30.v20200611'
     compile group: 'org.eclipse.jetty', name: 'apache-jsp', version: '9.4.30.v20200611'
     compile group: 'org.eclipse.jetty', name: 'apache-jstl', version: '9.4.30.v20200611'
+    compile group: 'commons-io', name: 'commons-io', version: '2.7'
     runtime project(':windows')
 }
 evaluationDependsOn(':windows')
@@ -185,3 +186,109 @@ task buildWindows(type: Exec) {
 buildWindows.dependsOn classes
 
 mainClassName='org.fruit.monkey.Main'
+
+
+/**
+ * Tasks to test TESTAR using gradle
+ */
+
+// Default COMMAND_LINE execution to run Notepad, execute 2 actions and verdict should be OK
+task runTestDesktopGenericCommandLineOk(type: Exec, dependsOn:'installDist') {
+	// Read command line output
+    standardOutput = new ByteArrayOutputStream()
+    group = 'test_testar_workflow'
+    description ='runTestDesktopGenericCommandLineOk'
+    workingDir 'target/install/testar/bin'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic ApplicationName="notepad_ok" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
+    doLast {
+        String output = standardOutput.toString()
+
+		// Check that output contains No problem detected. message to verify the correct execution
+        if(output.readLines().any{line->line.contains("No problem detected.")}) {
+            println "\n${output} \nTESTAR has been executed sucessfully"
+        } else {
+            throw new GradleException("\n${output} \nERROR: Executing TESTAR")
+        }
+    }
+}
+
+// Default COMMAND_LINE execution to run Notepad
+// Force TESTAR to find a Suspicious Title Error (Format widget)
+// And verify it reading output command line
+task runTestDesktopGenericCommandLineSuspiciousTitle(type: Exec, dependsOn:'installDist') {
+	// Read command line output
+    standardOutput = new ByteArrayOutputStream()
+    group = 'test_testar_workflow'
+    description ='runTestDesktopGenericCommandLineSuspiciousTitle'
+    workingDir 'target/install/testar/bin'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic ApplicationName="notepad_command_and_suspicious" SuspiciousTitles=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
+    doLast {
+        String output = standardOutput.toString()
+
+		// Use Format (for English and Spanish)
+        if(output.readLines().any{line->line.contains("Discovered suspicious widget 'Title' : 'Format")}) {
+            println "\n${output} \nTESTAR has successfully detected Format Suspicious Title! "
+        } else {
+            throw new GradleException("\n${output} \nERROR: TESTAR didnt detect Format Suspicious Title")
+        }
+    }
+}
+
+// Help task to run Notepad before start TESTAR (to connect with process or title)
+task runNotepad {
+    group = 'test_testar_workflow'
+    description ='runNotepad'
+    doFirst{
+        ext.process = new ProcessBuilder().command('cmd', '/c', 'C:\\Windows\\System32\\notepad.exe').start()
+    }
+}
+
+// Verify that TESTAR correctly connects using process name
+// To be sure, connect to process and detect Format suspicious title
+task runTestDesktopGenericProcessNameSuspiciousTitle(type: Exec, dependsOn:['installDist','runNotepad']) {
+	// Read command line output
+    standardOutput = new ByteArrayOutputStream()
+    group = 'test_testar_workflow'
+    description ='runTestDesktopGenericProcessNameSuspiciousTitle'
+    workingDir 'target/install/testar/bin'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic ApplicationName="notepad_process_and_suspicious" SuspiciousTitles=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=SUT_PROCESS_NAME SUTConnectorValue="notepad.exe" Sequences=1 SequenceLength=2'
+    doLast {
+        String output = standardOutput.toString()
+
+		// Use Format (for English and Spanish)
+        if(output.readLines().any{line->line.contains("Discovered suspicious widget 'Title' : 'Format")}) {
+            println "\n${output} \nTESTAR has successfully connect with SUT_PROCESS_NAME and detected Format Suspicious Title! "
+            // kill notepad process
+            ext.process = new ProcessBuilder().command('cmd', '/c', 'taskkill /IM notepad.exe').start()
+        } else {
+            // kill notepad process
+            ext.process = new ProcessBuilder().command('cmd', '/c', 'taskkill /IM notepad.exe').start()
+            throw new GradleException("\n${output} \nERROR: TESTAR didnt connect with SUT_PROCESS_NAME")
+        }
+    }
+}
+
+// Verify that TESTAR correctly connects using windows title
+// To be sure, connect with windows title and detect Format suspicious title
+task runTestDesktopGenericTitleNameSuspiciousTitle(type: Exec, dependsOn:['installDist','runNotepad']) {
+	// Read command line output
+    standardOutput = new ByteArrayOutputStream()
+    group = 'test_testar_workflow'
+    description ='runTestDesktopGenericTitleNameSuspiciousTitle'
+    workingDir 'target/install/testar/bin'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic ApplicationName="notepad_title_and_suspicious" SuspiciousTitles=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=SUT_WINDOW_TITLE SUTConnectorValue="Notepad" Sequences=1 SequenceLength=2'
+    doLast {
+        String output = standardOutput.toString()
+
+		// Use Format (for English and Spanish)
+        if(output.readLines().any{line->line.contains("Discovered suspicious widget 'Title' : 'Format")}) {
+            println "\n${output} \nTESTAR has successfully connect with SUT_WINDOW_TITLE and detected Format Suspicious Title! "
+            // kill notepad process
+            ext.process = new ProcessBuilder().command('cmd', '/c', 'taskkill /IM notepad.exe').start()
+        } else {
+            // kill notepad process
+            ext.process = new ProcessBuilder().command('cmd', '/c', 'taskkill /IM notepad.exe').start()
+            throw new GradleException("\n${output} \nERROR: TESTAR didnt connect with SUT_WINDOW_TITLE")
+        }
+    }
+}

--- a/testar/resources/settings/test_gradle_workflow_desktop_generic/Protocol_test_gradle_workflow_desktop_generic.java
+++ b/testar/resources/settings/test_gradle_workflow_desktop_generic/Protocol_test_gradle_workflow_desktop_generic.java
@@ -1,0 +1,99 @@
+/***************************************************************************************************
+ *
+ * Copyright (c) 2020 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2020 Open Universiteit - www.ou.nl
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************************************/
+
+
+import java.io.File;
+import java.util.Set;
+
+import org.apache.commons.io.FileUtils;
+import org.fruit.alayer.*;
+import org.fruit.alayer.exceptions.*;
+import org.fruit.monkey.ConfigTags;
+import org.fruit.monkey.Main;
+import org.testar.OutputStructure;
+import org.testar.protocols.DesktopProtocol;
+
+/**
+ * This protocol is used to test TESTAR by executing a gradle CI workflow.
+ * 
+ * ".github/workflows/gradle.yml"
+ */
+public class Protocol_test_gradle_workflow_desktop_generic extends DesktopProtocol {
+
+	@Override
+	protected State getState(SUT system) throws StateBuildException{
+		State state = super.getState(system);
+
+		// DEBUG: That widgets have screen bounds in the GUI of the remote server
+		for(Widget w : state) {
+			String debug = String.format("Widget: '%s' ", w.get(Tags.Title, ""));
+			if(w.get(Tags.Shape, null) != null) {
+				debug = debug.concat(String.format("with Shape: %s", w.get(Tags.Shape, null)));
+			}
+			System.out.println(debug);
+		}
+
+		return state;
+	}
+
+	@Override
+	protected Set<Action> deriveActions(SUT system, State state) throws ActionBuildException{
+
+		//The super method returns a ONLY actions for killing unwanted processes if needed, or bringing the SUT to
+		//the foreground. You should add all other actions here yourself.
+		// These "special" actions are prioritized over the normal GUI actions in selectAction() / preSelectAction().
+		Set<Action> actions = super.deriveActions(system,state);
+
+
+		// Derive left-click actions, click and type actions, and scroll actions from
+		// top level (highest Z-index) widgets of the GUI:
+		actions = deriveClickTypeScrollActionsFromTopLevelWidgets(actions, system, state);
+
+		if(actions.isEmpty()){
+			// If the top level widgets did not have any executable widgets, try all widgets:
+			// Derive left-click actions, click and type actions, and scroll actions from
+			// all widgets of the GUI:
+			actions = deriveClickTypeScrollActionsFromAllWidgetsOfState(actions, system, state);
+		}
+
+		//return the set of derived actions
+		return actions;
+	}
+
+	@Override
+	protected void closeTestSession() {
+		super.closeTestSession();
+		try {
+			File originalFolder = new File(OutputStructure.outerLoopOutputDir).getCanonicalFile();
+			File artifactFolder = new File(Main.testarDir + settings.get(ConfigTags.ApplicationName,""));
+			FileUtils.copyDirectory(originalFolder, artifactFolder);
+		} catch(Exception e) {System.out.println("ERROR: Creating Artifact Folder");}
+	}
+}

--- a/testar/resources/settings/test_gradle_workflow_desktop_generic/test.settings
+++ b/testar/resources/settings/test_gradle_workflow_desktop_generic/test.settings
@@ -1,0 +1,138 @@
+#################################################################
+# TESTAR mode
+#
+# Set the mode you want TESTAR to start in: Spy, Generate, Replay
+#################################################################
+
+Mode = Spy
+
+#################################################################
+# Connect to the System Under Test (SUT)
+#
+# Indicate how you want to connect to the SUT:
+#
+# SUTCONNECTOR = COMMAND_LINE, SUTConnectorValue property must be a command line that
+# starts the SUT.
+# It should work from a Command Prompt terminal window (e.g. java - jar SUTs/calc.jar ).
+# For web applications, follow the next format: web_browser_path SUT_URL.
+#
+# SUTCONNECTOR = SUT_WINDOW_TITLE, then SUTConnectorValue property must be the title displayed
+# in the SUT main window. The SUT must be manually started and closed.
+#
+# SUTCONNECTOR = SUT_PROCESS_NAME: SUTConnectorValue property must be the process name of the SUT.
+# The SUT must be manually started and closed.
+#################################################################
+SUTConnector = COMMAND_LINE
+SUTConnectorValue = c:\\windows\\system32\\notepad.exe
+
+#################################################################
+# Sequences
+#
+# Number of sequences and the length of these sequences
+#################################################################
+
+Sequences = 8
+SequenceLength = 10
+
+#################################################################
+# Oracles based on suspicious titles
+#
+# Regular expression
+#################################################################
+
+SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+
+#################################################################
+# Oracles based on Suspicious Outputs detected by Process Listeners
+#
+# Requires ProcessListenerEnabled
+# (Only available for desktop applications through COMMAND_LINE)
+#
+# Regular expression SuspiciousProcessOutput contains the specification
+# of what is considered to be suspicious output.
+#################################################################
+
+ProcessListenerEnabled = false
+SuspiciousProcessOutput = .*[eE]rror.*|.*[eE]xcep[ct]i[o?]n.*
+
+#################################################################
+# Process Logs
+#
+# Requires ProcessListenerEnabled
+# (Only available for desktop applications through COMMAND_LINE)
+#
+# Allow TESTAR to store execution logs coming from the processes.
+# You can use the regular expression ProcessLogs below to filter 
+# the logs. Use .*.* if you want to store all the outputs of the 
+# process.
+#################################################################
+
+ProcessLogs = .*.*
+
+#################################################################
+# Actionfilter
+#
+# Regular expression. More filters can be added in Spy mode,
+# these will be added to the protocol_filter.xml file.
+#################################################################
+
+ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+
+#################################################################
+# Processfilter
+#
+# Regular expression. Kill the processes that your SUT can start up
+# but that you do not want to test.
+#################################################################
+
+SUTProcesses =
+
+#################################################################
+# Protocolclass
+#
+# Indicate the location of the protocol class for your specific SUT.
+#################################################################
+
+ProtocolClass = test_gradle_workflow_desktop_generic/Protocol_test_gradle_workflow_desktop_generic
+
+#################################################################
+# State identifier attributes
+#
+# Specify the widget attributes that you wish to use in constructing
+# the widget and state hash strings. Use a comma separated list.
+#################################################################
+AbstractStateAttributes = WidgetControlType
+
+#################################################################
+# Other more advanced settings
+#################################################################
+
+ProcessesToKillDuringTest =
+OutputDir = ./output
+PathToReplaySequence = ./output/temp
+TempDir = ./output/temp
+UseRecordedActionDurationAndWaitTimeDuringReplay = false
+ForceForeground = true
+LogLevel = 1
+ExecuteActions = true
+FaultThreshold = 0.000000001
+DrawWidgetUnderCursor = true
+MyClassPath = ./settings
+OnlySaveFaultySequences = false
+ActionDuration = 0.1
+ShowVisualSettingsDialogOnStartup = true
+ReplayRetryTime = 30.0
+Delete =
+MaxTime = 3.1536E7
+ShowSettingsAfterTest = true
+TimeToWaitAfterAction = 0.1
+StartupTime = 10.0
+DrawWidgetInfo = false
+TimeToFreeze = 30.0
+StopGenerationOnFault = true
+CopyFromTo =
+VisualizeActions = false
+VisualizeSelectedAction = true
+TestGenerator = random
+MaxReward = 9999999
+Discount = .95

--- a/testar/src/org/testar/protocols/DesktopProtocol.java
+++ b/testar/src/org/testar/protocols/DesktopProtocol.java
@@ -184,6 +184,8 @@ public class DesktopProtocol extends GenericUtilsProtocol {
 				+ " " + settings.get(ConfigTags.Mode, mode())
 				+ " " + sequencesPath
 				+ " " + status + " \"" + statusInfo + "\"" );
+		
+		htmlReport.close();
     }
 
     /**

--- a/testar/src/org/testar/protocols/WebdriverProtocol.java
+++ b/testar/src/org/testar/protocols/WebdriverProtocol.java
@@ -348,6 +348,8 @@ public class WebdriverProtocol extends GenericUtilsProtocol {
     			+ " " + settings.get(ConfigTags.Mode, mode())
     			+ " " + sequencesPath
     			+ " " + status + " \"" + statusInfo + "\"" );
+    	
+    	htmlReport.close();
     }
     
     @Override


### PR DESCRIPTION
- Added gradle task group "test_testar_workflow" to test TESTAR
- Create specific "test_gradle_workflow_desktop_generic" protocol to debug the widget tree and create the output folder used to create workflow artifacts
- Added github gradle workflow file to invoke these gradle tasks and save these output artifacts
- NativeLinker now allows the execution of TESTAR in all Windows environments. (Github servers are using Windows Server 2019)