### PR TITLE
Fix build.gradle for Linux and MacOs environments

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,8 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
-
+  windows:
     runs-on: windows-latest
     timeout-minutes: 30
 
@@ -71,3 +70,37 @@ jobs:
       with:
         name: runTestWebdriverParabankLogin-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/webdriver_login
+
+  linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build TESTAR with Gradle
+      run: ./gradlew build
+    - name: Prepare installed distribution of TESTAR with Gradle
+      run: ./gradlew installDist
+
+  macos:
+    runs-on: macos-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build TESTAR with Gradle
+      run: ./gradlew build
+    - name: Prepare installed distribution of TESTAR with Gradle
+      run: ./gradlew installDist

--- a/testar/build.gradle
+++ b/testar/build.gradle
@@ -309,6 +309,11 @@ task downloadChromedriver(type: Download, dependsOn: installDist) {
     group = 'test_testar_workflow'
     description ='downloadChromedriver'
     
+    // Disable for non-Windows environments (Linux, osx)
+    if (!System.getProperty('os.name').toLowerCase().contains('windows')) {
+        return;
+    }
+    
     ProcessBuilder builder = new ProcessBuilder().command('cmd', '/c', 'curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE');
     Process process = builder.start();
     process.waitFor()
@@ -322,6 +327,12 @@ task downloadChromedriver(type: Download, dependsOn: installDist) {
 task downloadAndUnzipChromedriver(type: Copy, dependsOn: downloadChromedriver) {
     group = 'test_testar_workflow'
     description ='downloadAndUnzipChromedriver'
+    
+    // Disable for non-Windows environments (Linux, osx)
+    if (!System.getProperty('os.name').toLowerCase().contains('windows')) {
+        return;
+    }
+    
     from zipTree(new File(downloadChromedriver.dest, 'chromedriver_win32.zip'))
     into downloadChromedriver.dest
 }


### PR DESCRIPTION
Related to #253 , seems that gradle evaluates that `cmd` is not a Linux, macOs command, then the compilation of TESTAR (`gradle build` or `gradle installDist`) was not possible.

- In the evaluated tasks in which the `cmd` is used, check that we are in a windows environment
- Add workflow jobs for Ubuntu and macOs (Only compilation at the moment)
