### PR TITLE
Added a setting to filter multiple tags

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,6 +42,13 @@ jobs:
       with:
         name: runTestDesktopGenericCommandLineSuspiciousTitle-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_command_and_suspicious
+    - name: Run desktop_generic protocol using specific filtering and detect a SuspiciousTitle with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle
+    - name: Save runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle HTML report artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle-artifact
+        path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_command_settings_filter_and_suspicious
     - name: Run desktop_generic protocol but connect using SUT_PROCESS_NAME and detect SuspiciousTitle
       run: ./gradlew runTestDesktopGenericProcessNameSuspiciousTitle
     - name: Save runTestDesktopGenericProcessNameSuspiciousTitle HTML report artifact

--- a/testar/build.gradle
+++ b/testar/build.gradle
@@ -245,6 +245,29 @@ task runTestDesktopGenericCommandLineSuspiciousTitle(type: Exec, dependsOn:'inst
     }
 }
 
+// Default COMMAND_LINE execution to run Notepad
+// Test TagsToFilter feature using the Tag.Desc
+// Then force TESTAR to navigate and find a Suspicious Title Error (Script text)
+// And verify it reading output command line
+task runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle(type: Exec, dependsOn:'installDist') {
+	// Read command line output
+    standardOutput = new ByteArrayOutputStream()
+    group = 'test_testar_workflow'
+    description ='runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle'
+    workingDir 'target/install/testar/bin'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_settings_filter_and_suspicious" TagsToFilter="Desc" ClickFilter=".*[sS]ystem.*|.*[cC]lose.*|.*[mM]inimize.*|.*[mM]aximize.*|Text Editor|File|Edit|View|Help|Word Wrap" SuspiciousTitles=".*[sS]cript.*" TimeToWaitAfterAction=2.0 ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
+    doLast {
+        String output = standardOutput.toString()
+
+		// Verify Script title has been detected
+        if(output.readLines().any{line->line.contains("Discovered suspicious widget 'Title' : 'Script")}) {
+            println "\n${output} \nTESTAR has successfully filtered using TagsToFilter Desc and detected Script Suspicious Title! "
+        } else {
+            throw new GradleException("\n${output} \nERROR: TESTAR didnt filter using TagsToFilter Desc")
+        }
+    }
+}
+
 // Help task to run Notepad before start TESTAR (to connect with process or title)
 task runNotepad {
     group = 'test_testar_workflow'

--- a/testar/resources/settings/01_desktop_generic_pure_random/test.settings
+++ b/testar/resources/settings/01_desktop_generic_pure_random/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = 
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/02_webdriver_parabank/test.settings
+++ b/testar/resources/settings/02_webdriver_parabank/test.settings
@@ -76,11 +76,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]rint.*|.*[iI]mprimir.*|.*[eE]mail.*|.*[fF]ile.*|.*[aA]rchivo.*|.*[mM]inimize.*|.*[mM]inimizar.*|.*[dD]isconnect.*|.*[dD]esconectar.*
+TagsToFilter = Title;WebName;WebTagName
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_generic/test.settings
+++ b/testar/resources/settings/desktop_generic/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_generic_action_selection/test.settings
+++ b/testar/resources/settings/desktop_generic_action_selection/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[mM]aximi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_generic_all_features/test.settings
+++ b/testar/resources/settings/desktop_generic_all_features/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_generic_json/test.settings
+++ b/testar/resources/settings/desktop_generic_json/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_generic_statemodel/test.settings
+++ b/testar/resources/settings/desktop_generic_statemodel/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_qlearning/test.settings
+++ b/testar/resources/settings/desktop_qlearning/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_simple_stategraph/test.settings
+++ b/testar/resources/settings/desktop_simple_stategraph/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_simple_stategraph_eye/test.settings
+++ b/testar/resources/settings/desktop_simple_stategraph_eye/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_simple_stategraph_sikulix/test.settings
+++ b/testar/resources/settings/desktop_simple_stategraph_sikulix/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/desktop_swingset2/Protocol_desktop_SwingSet2.java
+++ b/testar/resources/settings/desktop_swingset2/Protocol_desktop_SwingSet2.java
@@ -1,32 +1,32 @@
 /***************************************************************************************************
-*
-* Copyright (c) 2017, 2018, 2019 Universitat Politecnica de Valencia - www.upv.es
-* Copyright (c) 2019 Open Universiteit - www.ou.nl
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-* notice, this list of conditions and the following disclaimer in the
-* documentation and/or other materials provided with the distribution.
-* 3. Neither the name of the copyright holder nor the names of its
-* contributors may be used to endorse or promote products derived from
-* this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*******************************************************************************************************/
+ *
+ * Copyright (c) 2017 - 2021 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2019 - 2021 Open Universiteit - www.ou.nl
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************************************/
 
 import java.util.Set;
 import org.fruit.alayer.Action;
@@ -48,71 +48,83 @@ import static org.fruit.alayer.Tags.Enabled;
 public class Protocol_desktop_SwingSet2 extends DesktopProtocol {
 
 
-	/**
-	 * This method is used by TESTAR to determine the set of currently available actions.
-	 * You can use the SUT's current state, analyze the widgets and their properties to create
-	 * a set of sensible actions, such as: "Click every Button which is enabled" etc.
-	 * The return value is supposed to be non-null. If the returned set is empty, TESTAR
-	 * will stop generation of the current action and continue with the next one.
-	 * @param system the SUT
-	 * @param state the SUT's current state
-	 * @return  a set of actions
-	 */
+    /**
+     * This method is used by TESTAR to determine the set of currently available actions.
+     * You can use the SUT's current state, analyze the widgets and their properties to create
+     * a set of sensible actions, such as: "Click every Button which is enabled" etc.
+     * The return value is supposed to be non-null. If the returned set is empty, TESTAR
+     * will stop generation of the current action and continue with the next one.
+     * @param system the SUT
+     * @param state the SUT's current state
+     * @return  a set of actions
+     */
 
-	protected Set<Action> deriveActions(SUT system, State state) throws ActionBuildException{
+    protected Set<Action> deriveActions(SUT system, State state) throws ActionBuildException{
 
-		Set<Action> actions = super.deriveActions(system,state);
-		// unwanted processes, force SUT to foreground, ... actions automatically derived!
+        Set<Action> actions = super.deriveActions(system,state);
+        // unwanted processes, force SUT to foreground, ... actions automatically derived!
 
-		// create an action compiler, which helps us create actions, such as clicks, drag&drop, typing ...
-		StdActionCompiler ac = new AnnotatingActionCompiler();
-		
-		//----------------------
-		// BUILD CUSTOM ACTIONS
-		//----------------------
-		
-		// iterate through all widgets
-		for(Widget w : getTopWidgets(state)){
+        // create an action compiler, which helps us create actions, such as clicks, drag&drop, typing ...
+        StdActionCompiler ac = new AnnotatingActionCompiler();
 
-			if(w.get(Enabled, true) && !w.get(Blocked, false)){ // only consider enabled and non-blocked widgets
-				
-				if (!blackListed(w)){  // do not build actions for tabu widgets  
-					
-					// left clicks
-					if(whiteListed(w) || isClickable(w))
-						actions.add(ac.leftClickAt(w));
-	
-					// type into text boxes
-					if(isTypeable(w))
-						actions.add(ac.clickTypeInto(w, this.getRandomText(w), true));
-					
-					//Force actions on some widgets with a wrong accessibility
-					//Optional, comment this changes if your Swing applications doesn't need it
+        //----------------------
+        // BUILD CUSTOM ACTIONS
+        //----------------------
 
-					if(w.get(Tags.Role).toString().contains("Tree") ||
-						w.get(Tags.Role).toString().contains("ComboBox") ||
-						w.get(Tags.Role).toString().contains("List")) {
-						widgetTree(w, actions);
-					}
-					//End of Force action
+        // iterate through all widgets
+        for(Widget w : getTopWidgets(state)){
 
-				}
-				
-			}
+            if(w.get(Enabled, true) && !w.get(Blocked, false)){ // only consider enabled and non-blocked widgets
 
-		}
-		
-		return actions;
+                if (!blackListed(w)){  // do not build actions for tabu widgets  
 
-	}
-	
-	//Force actions on Tree widgets with a wrong accessibility
-	public void widgetTree(Widget w, Set<Action> actions) {
-		StdActionCompiler ac = new AnnotatingActionCompiler();
-		actions.add(ac.leftClickAt(w));
-		w.set(Tags.ActionSet, actions);
-		for(int i = 0; i<w.childCount(); i++) {
-			widgetTree(w.child(i), actions);
-		}
-	}
+                    // left clicks
+                    if(isClickable(w) && (isUnfiltered(w) || whiteListed(w))) {
+                        actions.add(ac.leftClickAt(w));
+                    }
+
+                    // type into text boxes
+                    if((isTypeable(w) && (isUnfiltered(w) || whiteListed(w))) && !isSourceCodeEditWidget(w)) {
+                        actions.add(ac.clickTypeInto(w, this.getRandomText(w), true));
+                    }
+
+                    //Force actions on some widgets with a wrong accessibility
+                    //Optional, comment this changes if your Swing applications doesn't need it
+
+                    if(w.get(Tags.Role).toString().contains("Tree") ||
+                            w.get(Tags.Role).toString().contains("ComboBox") ||
+                            w.get(Tags.Role).toString().contains("List")) {
+                        widgetTree(w, actions);
+                    }
+                    //End of Force action
+
+                }
+
+            }
+
+        }
+
+        return actions;
+
+    }
+
+    /**
+     * SwingSet2 application contains a TabElement called "SourceCode"
+     * that internally contains UIAEdit widgets that are not modifiable.
+     * Because these widgets have the property ToolTipText with the value "text/html",
+     * use this Tag to recognize and ignore.
+     */
+    private boolean isSourceCodeEditWidget(Widget w) {
+        return w.get(Tags.ToolTipText, "").contains("text/html");
+    }
+
+    //Force actions on Tree widgets with a wrong accessibility
+    public void widgetTree(Widget w, Set<Action> actions) {
+        StdActionCompiler ac = new AnnotatingActionCompiler();
+        actions.add(ac.leftClickAt(w));
+        w.set(Tags.ActionSet, actions);
+        for(int i = 0; i<w.childCount(); i++) {
+            widgetTree(w.child(i), actions);
+        }
+    }
 }

--- a/testar/resources/settings/desktop_swingset2/test.settings
+++ b/testar/resources/settings/desktop_swingset2/test.settings
@@ -83,11 +83,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[eE]xit.*|.*Close.*|.*[sS]ave.*|.*Minimize.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/webdriver_detect_similarity/test.settings
+++ b/testar/resources/settings/webdriver_detect_similarity/test.settings
@@ -76,11 +76,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]rint.*|.*[iI]mprimir.*|.*[eE]mail.*|.*[fF]ile.*|.*[aA]rchivo.*|.*[mM]inimize.*|.*[mM]inimizar.*|.*[dD]isconnect.*|.*[dD]esconectar.*
+TagsToFilter = Title;WebName;WebTagName
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/webdriver_generic/test.settings
+++ b/testar/resources/settings/webdriver_generic/test.settings
@@ -76,11 +76,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]rint.*|.*[iI]mprimir.*|.*[eE]mail.*|.*[fF]ile.*|.*[aA]rchivo.*|.*[mM]inimize.*|.*[mM]inimizar.*|.*[dD]isconnect.*|.*[dD]esconectar.*
+TagsToFilter = Title;WebName;WebTagName
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/webdriver_gwt/test.settings
+++ b/testar/resources/settings/webdriver_gwt/test.settings
@@ -76,11 +76,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]rint.*|.*[iI]mprimir.*|.*[eE]mail.*|.*[fF]ile.*|.*[aA]rchivo.*|.*[mM]inimize.*|.*[mM]inimizar.*|.*[dD]isconnect.*|.*[dD]esconectar.*
+TagsToFilter = Title;WebName;WebTagName
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/webdriver_spy_custom/test.settings
+++ b/testar/resources/settings/webdriver_spy_custom/test.settings
@@ -76,11 +76,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]rint.*|.*[iI]mprimir.*|.*[eE]mail.*|.*[fF]ile.*|.*[aA]rchivo.*|.*[mM]inimize.*|.*[mM]inimizar.*|.*[dD]isconnect.*|.*[dD]esconectar.*
+TagsToFilter = Title;WebName;WebTagName
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/webdriver_statemodel/test.settings
+++ b/testar/resources/settings/webdriver_statemodel/test.settings
@@ -76,11 +76,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]rint.*|.*[iI]mprimir.*|.*[eE]mail.*|.*[fF]ile.*|.*[aA]rchivo.*|.*[mM]inimize.*|.*[mM]inimizar.*|.*[dD]isconnect.*|.*[dD]esconectar.*
+TagsToFilter = Title;WebName;WebTagName
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/winapi_web_generic/test.settings
+++ b/testar/resources/settings/winapi_web_generic/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]rint.*|.*[iI]mprimir.*|.*[eE]mail.*|.*[fF]ile.*|.*[aA]rchivo.*|.*[mM]inimize.*|.*[mM]inimizar.*|.*[dD]isconnect.*|.*[dD]esconectar.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/resources/settings/winapi_web_one_drive/test.settings
+++ b/testar/resources/settings/winapi_web_one_drive/test.settings
@@ -72,11 +72,13 @@ ProcessLogs = .*.*
 #################################################################
 # Actionfilter
 #
-# Regular expression. More filters can be added in Spy mode,
+# Regular expression and Tags to apply them.
+# More filters can be added in Spy mode,
 # these will be added to the protocol_filter.xml file.
 #################################################################
 
 ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]rint.*|.*[iI]mprimir.*|.*[eE]mail.*|.*[fF]ile.*|.*[aA]rchivo.*|.*[mM]inimize.*|.*[mM]inimizar.*|.*[dD]isconnect.*|.*[dD]esconectar.*
+TagsToFilter = Title
 
 #################################################################
 # Processfilter

--- a/testar/src/org/fruit/monkey/ConfigTags.java
+++ b/testar/src/org/fruit/monkey/ConfigTags.java
@@ -138,6 +138,7 @@ public final class ConfigTags {
   public static final Tag<List<String>> DeniedExtensions = Tag.from("DeniedExtensions", (Class<List<String>>) (Class<?>) List.class);
   @SuppressWarnings("unchecked")
   public static final Tag<List<String>> DomainsAllowed = Tag.from("DomainsAllowed", (Class<List<String>>) (Class<?>) List.class);
+  public static final Tag<List<String>> TagsToFilter = Tag.from("TagsToFilter", (Class<List<String>>) (Class<?>) List.class);
   public static final Tag<Boolean> FollowLinks = Tag.from("FollowLinks", Boolean.class);
   public static final Tag<Boolean> BrowserFullScreen = Tag.from("BrowserFullScreen", Boolean.class);
   public static final Tag<Boolean> SwitchNewTabs = Tag.from("SwitchNewTabs", Boolean.class);

--- a/testar/src/org/fruit/monkey/Main.java
+++ b/testar/src/org/fruit/monkey/Main.java
@@ -519,6 +519,14 @@ public class Main {
 				}
 			}));
 
+            defaults.add(Pair.from(TagsToFilter, new ArrayList<String>() {
+                {
+                    add("Title");
+                    add("WebName");
+                    add("WebTagName");
+                }
+            }));
+
 			defaults.add(Pair.from(FollowLinks, true));
 			defaults.add(Pair.from(BrowserFullScreen, true));
 			defaults.add(Pair.from(SwitchNewTabs, true));

--- a/testar/src/org/fruit/monkey/Settings.java
+++ b/testar/src/org/fruit/monkey/Settings.java
@@ -348,11 +348,13 @@ public class Settings extends TaggableBase implements Serializable {
 					+"#################################################################\n"
 					+"# Actionfilter\n"
 					+"#\n"
-					+"# Regular expression. More filters can be added in Spy mode,\n"
+					+"# Regular expression and Tags to apply them.\n"
+					+"# More filters can be added in Spy mode,\n"
 					+"# these will be added to the protocol_filter.xml file.\n"
 					+"#################################################################\n"
 					+"\n"
 					+"ClickFilter = " + Util.lineSep()
+					+"TagsToFilter = " + Util.lineSep()
 					+"\n"
 					+"#################################################################\n"
 					+"# Processfilter\n"

--- a/testar/src/org/fruit/monkey/SettingsDialog.java
+++ b/testar/src/org/fruit/monkey/SettingsDialog.java
@@ -72,7 +72,7 @@ import static org.fruit.monkey.dialog.ToolTipTexts.*;
 public class SettingsDialog extends JFrame implements Observer {
   private static final long serialVersionUID = 5156320008281200950L;
 
-  static final String TESTAR_VERSION = "2.2.15 (13-April-2021)";
+  static final String TESTAR_VERSION = "2.2.16 (27-April-2021)";
 
   private String settingsFile;
   private Settings settings;

--- a/testar/src/org/fruit/monkey/dialog/FilterPanel.java
+++ b/testar/src/org/fruit/monkey/dialog/FilterPanel.java
@@ -1,125 +1,114 @@
 /***************************************************************************************************
-*
-* Copyright (c) 2013 - 2020 Universitat Politecnica de Valencia - www.upv.es
-* Copyright (c) 2018 - 2020 Open Universiteit - www.ou.nl
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-* notice, this list of conditions and the following disclaimer in the
-* documentation and/or other materials provided with the distribution.
-* 3. Neither the name of the copyright holder nor the names of its
-* contributors may be used to endorse or promote products derived from
-* this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*******************************************************************************************************/
-
+ *
+ * Copyright (c) 2013 - 2021 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2018 - 2021 Open Universiteit - www.ou.nl
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************************************/
 
 package org.fruit.monkey.dialog;
 
+import org.apache.commons.lang3.StringUtils;
 import org.fruit.monkey.ConfigTags;
 import org.fruit.monkey.Settings;
 import org.fruit.monkey.SettingsPanel;
 
 import javax.swing.*;
 
-import static javax.swing.GroupLayout.DEFAULT_SIZE;
-import static javax.swing.GroupLayout.PREFERRED_SIZE;
 import static org.fruit.monkey.dialog.ToolTipTexts.label1TTT;
 import static org.fruit.monkey.dialog.ToolTipTexts.label2TTT;
 
+import java.util.Arrays;
+
 public class FilterPanel extends SettingsPanel {
 
-  private static final long serialVersionUID = 1572649050808020748L;
- 
-  private JTextArea txtClickFilter;
-  private JTextArea txtProcessFilter;
+    private static final long serialVersionUID = 1572649050808020748L;
 
-  public FilterPanel() {
-    JLabel filterByTitleLabel = new JLabel(
-        "Filter actions by the widget its TITLE property (regular expression):");
-    filterByTitleLabel.setToolTipText(label1TTT);
-    JLabel killProcessByNameLabel = new JLabel(
-        "Kill processes by name (regular expression):");
-    killProcessByNameLabel.setToolTipText(label2TTT);
+    private JLabel filterLabel = new JLabel("Filter actions on the widgets based on Tags values (regular expression):");
+    private JLabel filterTags = new JLabel("Tags to apply the filters (semicolon to customize multiple Tags)");
+    private JLabel killProcessLabel = new JLabel("Kill processes by name (regular expression):");
 
-    JScrollPane filterByTitlePane = new JScrollPane();
-    JScrollPane killProcessByNamePane = new JScrollPane();
+    private JTextArea txtClickFilter = new JTextArea();
+    private JTextArea txtTagsToFilter = new JTextArea();
+    private JTextArea txtProcessFilter = new JTextArea();
 
-    GroupLayout gl_jPanelFilters = new GroupLayout(this);
-    this.setLayout(gl_jPanelFilters);
-    gl_jPanelFilters.setHorizontalGroup(
-        gl_jPanelFilters.createParallelGroup(GroupLayout.Alignment.LEADING)
-            .addGroup(gl_jPanelFilters.createSequentialGroup()
-                .addGroup(gl_jPanelFilters.createParallelGroup(GroupLayout.Alignment.LEADING)
-                    .addGroup(gl_jPanelFilters.createSequentialGroup()
-                        .addGap(24)
-                        .addComponent(killProcessByNamePane, PREFERRED_SIZE, 572, PREFERRED_SIZE))
-                    .addGroup(gl_jPanelFilters.createSequentialGroup()
-                        .addGap(24)
-                        .addComponent(filterByTitlePane, PREFERRED_SIZE, 572, PREFERRED_SIZE))
-                    .addGroup(gl_jPanelFilters.createSequentialGroup()
-                        .addContainerGap()
-                        .addGroup(gl_jPanelFilters.createParallelGroup(GroupLayout.Alignment.LEADING)
-                            .addComponent(killProcessByNameLabel, PREFERRED_SIZE, 357, PREFERRED_SIZE)
-                            .addComponent(filterByTitleLabel, PREFERRED_SIZE, 381, PREFERRED_SIZE))))
-                .addContainerGap(24, Short.MAX_VALUE))
-    );
-    gl_jPanelFilters.setVerticalGroup(
-        gl_jPanelFilters.createParallelGroup(GroupLayout.Alignment.LEADING)
-            .addGroup(gl_jPanelFilters.createSequentialGroup()
-                .addContainerGap()
-                .addComponent(filterByTitleLabel)
-                .addGap(18)
-                .addComponent(filterByTitlePane, DEFAULT_SIZE, 108, Short.MAX_VALUE)
-                .addGap(18)
-                .addComponent(killProcessByNameLabel)
-                .addGap(18)
-                .addComponent(killProcessByNamePane, PREFERRED_SIZE, 121, PREFERRED_SIZE)
-                .addGap(22))
-    );
+    public FilterPanel() {
+        filterLabel.setToolTipText(label1TTT);
+        killProcessLabel.setToolTipText(label2TTT);
 
-    txtProcessFilter = new JTextArea();
-    txtProcessFilter.setLineWrap(true);
-    killProcessByNamePane.setViewportView(txtProcessFilter);
+        setLayout(null);
+        filterLabel.setBounds(10, 5, 600, 27);
+        add(filterLabel);
 
-    txtClickFilter = new JTextArea();
-    txtClickFilter.setLineWrap(true);
-    filterByTitlePane.setViewportView(txtClickFilter);
+        txtClickFilter.setLineWrap(true);
+        JScrollPane clickFilterPane = new JScrollPane(txtClickFilter);
+        clickFilterPane.setBounds(10, 35, 600, 100);
+        clickFilterPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        clickFilterPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        add(clickFilterPane);
 
-  }
+        filterTags.setBounds(10, 130, 600, 27);
+        add(filterTags);
 
-  /**
-   * Populate Filter Fields from Settings structure.
-   * @param settings The settings to load.
-   */
-  @Override
-  public void populateFrom(final Settings settings) {
-    txtClickFilter.setText(settings.get(ConfigTags.ClickFilter));
-    txtProcessFilter.setText(settings.get(ConfigTags.ProcessesToKillDuringTest));
-  }
+        txtTagsToFilter.setLineWrap(true);
+        JScrollPane tagsToFilterPane = new JScrollPane(txtTagsToFilter);
+        tagsToFilterPane.setBounds(10, 160, 600, 50);
+        tagsToFilterPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        tagsToFilterPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        add(tagsToFilterPane);
 
-  /**
-   * Retrieve information from the Filter  GUI.
-   * @param settings reference to the object where the settings will be stored.
-   */
-  @Override
-  public void extractInformation(final Settings settings) {
-    settings.set(ConfigTags.ClickFilter, txtClickFilter.getText());
-    settings.set(ConfigTags.ProcessesToKillDuringTest, txtProcessFilter.getText());
-  }
+        killProcessLabel.setBounds(10, 210, 600, 27);
+        add(killProcessLabel);
+
+        txtProcessFilter.setLineWrap(true);
+        JScrollPane processFilterPane = new JScrollPane(txtProcessFilter);
+        processFilterPane.setBounds(10, 240, 600, 100);
+        processFilterPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        processFilterPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        add(processFilterPane);
+    }
+
+    /**
+     * Populate Filter Fields from Settings structure.
+     * @param settings The settings to load.
+     */
+    @Override
+    public void populateFrom(final Settings settings) {
+        txtClickFilter.setText(settings.get(ConfigTags.ClickFilter));
+        txtTagsToFilter.setText(StringUtils.join(settings.get(ConfigTags.TagsToFilter), ";"));
+        txtProcessFilter.setText(settings.get(ConfigTags.ProcessesToKillDuringTest));
+    }
+
+    /**
+     * Retrieve information from the Filter  GUI.
+     * @param settings reference to the object where the settings will be stored.
+     */
+    @Override
+    public void extractInformation(final Settings settings) {
+        settings.set(ConfigTags.ClickFilter, txtClickFilter.getText());
+        settings.set(ConfigTags.TagsToFilter, Arrays.asList(txtTagsToFilter.getText().split(";")));
+        settings.set(ConfigTags.ProcessesToKillDuringTest, txtProcessFilter.getText());
+    }
 }

--- a/testar/src/org/testar/protocols/GenericUtilsProtocol.java
+++ b/testar/src/org/testar/protocols/GenericUtilsProtocol.java
@@ -1,7 +1,7 @@
 /***************************************************************************************************
  *
- * Copyright (c) 2020 Open Universiteit - www.ou.nl
- * Copyright (c) 2020 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2020 - 2021 Open Universiteit - www.ou.nl
+ * Copyright (c) 2020 - 2021 Universitat Politecnica de Valencia - www.upv.es
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -48,8 +48,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.fruit.alayer.Tags.Title;
 
 public class GenericUtilsProtocol extends ClickFilterLayerProtocol {
 
@@ -297,12 +295,12 @@ public class GenericUtilsProtocol extends ClickFilterLayerProtocol {
 
         Boolean isFiltered = false;
 
-        for(String tagToFilter:settings.get(ConfigTags.TagsToFilter)){
+        for(String tagToFilter : settings.get(ConfigTags.TagsToFilter)){
             String tagValue = "";
             // First finding the Tag that matches the TagsToFilter string, then getting the value of that Tag:
-            for(Tag tag:w.tags()){
+            for(Tag tag : w.tags()){
                 if(tag.name().equals(tagToFilter)){
-                    tagValue=w.get(tag, "");
+                    tagValue = w.get(tag, "");
                     //System.out.println("DEBUG: tag found, "+tagToFilter+"="+tagValue);
                 }
             }

--- a/testar/src/org/testar/protocols/GenericUtilsProtocol.java
+++ b/testar/src/org/testar/protocols/GenericUtilsProtocol.java
@@ -295,25 +295,42 @@ public class GenericUtilsProtocol extends ClickFilterLayerProtocol {
         if(!Util.hitTest(w, 0.5, 0.5))
             return false;
 
-        //Check whether the widget has an empty title or no title
-        //If it has, it is unfiltered
-        //Because it cannot match the regular expression of the Action Filter.
-        String title = w.get(Title, "");
-        if (title == null || title.isEmpty())
-            return true;
+        Boolean isFiltered = false;
 
-        //If no clickFilterPattern exists, then create it
-        //Get the clickFilterPattern from the regular expression provided by the tester in the Dialog
-        if (this.clickFilterPattern == null)
-            this.clickFilterPattern = Pattern.compile(settings().get(ConfigTags.ClickFilter), Pattern.UNICODE_CHARACTER_CLASS);
+        for(String tagToFilter:settings.get(ConfigTags.TagsToFilter)){
+            String tagValue = "";
+            // First finding the Tag that matches the TagsToFilter string, then getting the value of that Tag:
+            for(Tag tag:w.tags()){
+                if(tag.name().equals(tagToFilter)){
+                    tagValue=w.get(tag, "");
+                    //System.out.println("DEBUG: tag found, "+tagToFilter+"="+tagValue);
+                }
+            }
 
-        //Check whether the title matches any of the clickFilterPatterns
-        Matcher m = this.clickFilterMatchers.get(title);
-        if (m == null){
-            m = this.clickFilterPattern.matcher(title);
-            this.clickFilterMatchers.put(title, m);
+            //Check whether the Tag value is empty or null
+            //If it is, it is unfiltered
+            //Because it cannot match the regular expression of the Action Filter.
+            if (tagValue == null || tagValue.isEmpty())
+                continue; //no action, isFiltered is still false (cannot return directly if other Tags are checked)
+
+            //If no clickFilterPattern exists, then create it
+            //Get the clickFilterPattern from the regular expression provided by the tester in the Dialog
+            if (this.clickFilterPattern == null)
+                this.clickFilterPattern = Pattern.compile(settings().get(ConfigTags.ClickFilter), Pattern.UNICODE_CHARACTER_CLASS);
+
+            //Check whether the title matches any of the clickFilterPatterns
+            Matcher m = this.clickFilterMatchers.get(tagValue);
+            if (m == null){
+                m = this.clickFilterPattern.matcher(tagValue);
+                this.clickFilterMatchers.put(tagValue, m);
+            }
+            isFiltered = m.matches();
+            // if filtered, no need to check if it should be filtered multiple times:
+            if(isFiltered) return(!isFiltered); //method is for is-UN-filtered
+
         }
-        return !m.matches();
+        //method is for is-UN-filtered
+        return !isFiltered;
     }
 
     /**


### PR DESCRIPTION
TESTAR was filtering actions only based on Title tag, but now there is a new setting TagsToFilter where multiple tag names can be put and the same RegEx is used to check all of them.

Title filtering still works on Desktop_generic and WebDriver should now filter also other fields based on settings.