### PR TITLE
Add a new setting to detect suspicious titles on multiple tags

### DIFF
--- a/core/src/org/fruit/alayer/Tags.java
+++ b/core/src/org/fruit/alayer/Tags.java
@@ -1,7 +1,7 @@
 /***************************************************************************************************
 *
-* Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 Universitat Politecnica de Valencia - www.upv.es
-* Copyright (c) 2018, 2019, 2020 Open Universiteit - www.ou.nl
+* Copyright (c) 2013 - 2021 Universitat Politecnica de Valencia - www.upv.es
+* Copyright (c) 2018 - 2021 Open Universiteit - www.ou.nl
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are met:
@@ -44,7 +44,6 @@ import org.fruit.alayer.devices.ProcessHandle;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;

--- a/core/src/org/fruit/alayer/Tags.java
+++ b/core/src/org/fruit/alayer/Tags.java
@@ -217,15 +217,4 @@ public final class Tags extends TagsBase {
 	 */
 	public static final Tag<Widget> OriginWidget = from("OriginWidget", Widget.class);
 	
-	private static Set<Tag<String>> generalStringVerdictTags;
-	static {
-		generalStringVerdictTags = new HashSet<Tag<String>>();
-		generalStringVerdictTags.add(Title);
-		generalStringVerdictTags.add(ValuePattern);
-	}
-
-	public static Set<Tag<String>> getGeneralStringVerdictTags() {
-		return generalStringVerdictTags;
-	}
-	
 }

--- a/testar/build.gradle
+++ b/testar/build.gradle
@@ -224,7 +224,8 @@ task runTestDesktopGenericCommandLineOk(type: Exec, dependsOn:'installDist') {
 }
 
 // Default COMMAND_LINE execution to run Notepad
-// Force TESTAR to find a Suspicious Title Error (Format widget)
+// Test TagsForSuspiciousOracle feature using the UIATags.UIAAutomationId
+// Force TESTAR to find a Suspicious Title (MenuBar widget)
 // And verify it reading output command line
 task runTestDesktopGenericCommandLineSuspiciousTitle(type: Exec, dependsOn:'installDist') {
 	// Read command line output
@@ -232,15 +233,15 @@ task runTestDesktopGenericCommandLineSuspiciousTitle(type: Exec, dependsOn:'inst
     group = 'test_testar_workflow'
     description ='runTestDesktopGenericCommandLineSuspiciousTitle'
     workingDir 'target/install/testar/bin'
-    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_and_suspicious" SuspiciousTitles=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_and_suspicious" TagsForSuspiciousOracle="NotExist;UIAAutomationId" SuspiciousTitles=".*MenuBar.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
     doLast {
         String output = standardOutput.toString()
 
-		// Use Format (for English and Spanish)
-        if(output.readLines().any{line->line.contains("Discovered suspicious widget 'Title' : 'Format")}) {
-            println "\n${output} \nTESTAR has successfully detected Format Suspicious Title! "
+		// Verify MenuBar UIAAutomationId has been detected
+        if(output.readLines().any{line->line.contains("Discovered suspicious widget 'UIAAutomationId' : 'MenuBar")}) {
+            println "\n${output} \nTESTAR has successfully detected MenuBar Suspicious Title using TagsForSuspiciousOracle UIAAutomationId! "
         } else {
-            throw new GradleException("\n${output} \nERROR: TESTAR didnt detect Format Suspicious Title")
+            throw new GradleException("\n${output} \nERROR: TESTAR didnt detect MenuBar Suspicious Title using TagsForSuspiciousOracle UIAAutomationId")
         }
     }
 }
@@ -255,7 +256,7 @@ task runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle(type: Exec, d
     group = 'test_testar_workflow'
     description ='runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle'
     workingDir 'target/install/testar/bin'
-    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_settings_filter_and_suspicious" TagsToFilter="Desc" ClickFilter=".*[sS]ystem.*|.*[cC]lose.*|.*[mM]inimize.*|.*[mM]aximize.*|Text Editor|File|Edit|View|Help|Word Wrap" SuspiciousTitles=".*[sS]cript.*" TimeToWaitAfterAction=2.0 ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_settings_filter_and_suspicious" TagsToFilter="NotExist;Desc" ClickFilter=".*[sS]ystem.*|.*[cC]lose.*|.*[mM]inimize.*|.*[mM]aximize.*|Text Editor|File|Edit|View|Help|Word Wrap" SuspiciousTitles=".*[sS]cript.*" TimeToWaitAfterAction=2.0 ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
     doLast {
         String output = standardOutput.toString()
 

--- a/testar/build.gradle
+++ b/testar/build.gradle
@@ -369,7 +369,7 @@ task runTestWebdriverSuspiciousTitle(type: Exec, dependsOn: downloadAndUnzipChro
     group = 'test_testar_workflow'
     description ='runTestWebdriverSuspiciousTitle'
     workingDir 'target/install/testar/bin'
-    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_webdriver_generic AlwaysCompile=true ApplicationName="webdriver_and_suspicious" SuspiciousTitles=".*[oO]nderwijs.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate Sequences=1 SequenceLength=2'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_webdriver_generic AlwaysCompile=true ApplicationName="webdriver_and_suspicious" TagsForSuspiciousOracle="NotExist;ValuePattern" SuspiciousTitles=".*[oO]nderwijs.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate Sequences=1 SequenceLength=2'
     doLast {
         String output = standardOutput.toString()
 

--- a/testar/resources/settings/01_desktop_generic_pure_random/test.settings
+++ b/testar/resources/settings/01_desktop_generic_pure_random/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 20
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = 
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/02_webdriver_parabank/test.settings
+++ b/testar/resources/settings/02_webdriver_parabank/test.settings
@@ -41,10 +41,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_generic/test.settings
+++ b/testar/resources/settings/desktop_generic/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 10
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_generic_action_selection/test.settings
+++ b/testar/resources/settings/desktop_generic_action_selection/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 50
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_generic_all_features/test.settings
+++ b/testar/resources/settings/desktop_generic_all_features/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_generic_json/test.settings
+++ b/testar/resources/settings/desktop_generic_json/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_generic_statemodel/test.settings
+++ b/testar/resources/settings/desktop_generic_statemodel/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 10
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcep[ct]i[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_qlearning/test.settings
+++ b/testar/resources/settings/desktop_qlearning/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcep[ct]i[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_simple_stategraph/test.settings
+++ b/testar/resources/settings/desktop_simple_stategraph/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcep[ct]i[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_simple_stategraph_eye/test.settings
+++ b/testar/resources/settings/desktop_simple_stategraph_eye/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcep[ct]i[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_simple_stategraph_sikulix/test.settings
+++ b/testar/resources/settings/desktop_simple_stategraph_sikulix/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcep[ct]i[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/desktop_swingset2/test.settings
+++ b/testar/resources/settings/desktop_swingset2/test.settings
@@ -48,10 +48,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/webdriver_detect_similarity/test.settings
+++ b/testar/resources/settings/webdriver_detect_similarity/test.settings
@@ -41,10 +41,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/webdriver_generic/test.settings
+++ b/testar/resources/settings/webdriver_generic/test.settings
@@ -41,10 +41,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/webdriver_gwt/test.settings
+++ b/testar/resources/settings/webdriver_gwt/test.settings
@@ -41,10 +41,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/webdriver_spy_custom/test.settings
+++ b/testar/resources/settings/webdriver_spy_custom/test.settings
@@ -41,10 +41,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/webdriver_statemodel/test.settings
+++ b/testar/resources/settings/webdriver_statemodel/test.settings
@@ -41,10 +41,11 @@ SequenceLength = 20
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/winapi_web_generic/test.settings
+++ b/testar/resources/settings/winapi_web_generic/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/resources/settings/winapi_web_one_drive/test.settings
+++ b/testar/resources/settings/winapi_web_one_drive/test.settings
@@ -37,10 +37,11 @@ SequenceLength = 100
 #################################################################
 # Oracles based on suspicious titles
 #
-# Regular expression
+# Regular expression and Tags to apply them
 #################################################################
 
 SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+TagsForSuspiciousOracle = Title
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners

--- a/testar/src/org/fruit/monkey/ConfigTags.java
+++ b/testar/src/org/fruit/monkey/ConfigTags.java
@@ -139,6 +139,7 @@ public final class ConfigTags {
   @SuppressWarnings("unchecked")
   public static final Tag<List<String>> DomainsAllowed = Tag.from("DomainsAllowed", (Class<List<String>>) (Class<?>) List.class);
   public static final Tag<List<String>> TagsToFilter = Tag.from("TagsToFilter", (Class<List<String>>) (Class<?>) List.class);
+  public static final Tag<List<String>> TagsForSuspiciousOracle = Tag.from("TagsForSuspiciousOracle", (Class<List<String>>) (Class<?>) List.class);
   public static final Tag<Boolean> FollowLinks = Tag.from("FollowLinks", Boolean.class);
   public static final Tag<Boolean> BrowserFullScreen = Tag.from("BrowserFullScreen", Boolean.class);
   public static final Tag<Boolean> SwitchNewTabs = Tag.from("SwitchNewTabs", Boolean.class);

--- a/testar/src/org/fruit/monkey/ConfigTags.java
+++ b/testar/src/org/fruit/monkey/ConfigTags.java
@@ -34,7 +34,6 @@ package org.fruit.monkey;
 import org.fruit.Pair;
 import org.fruit.alayer.Tag;
 
-import java.nio.file.Path;
 import java.util.List;
 
 public final class ConfigTags {
@@ -138,7 +137,9 @@ public final class ConfigTags {
   public static final Tag<List<String>> DeniedExtensions = Tag.from("DeniedExtensions", (Class<List<String>>) (Class<?>) List.class);
   @SuppressWarnings("unchecked")
   public static final Tag<List<String>> DomainsAllowed = Tag.from("DomainsAllowed", (Class<List<String>>) (Class<?>) List.class);
+  @SuppressWarnings("unchecked")
   public static final Tag<List<String>> TagsToFilter = Tag.from("TagsToFilter", (Class<List<String>>) (Class<?>) List.class);
+  @SuppressWarnings("unchecked")
   public static final Tag<List<String>> TagsForSuspiciousOracle = Tag.from("TagsForSuspiciousOracle", (Class<List<String>>) (Class<?>) List.class);
   public static final Tag<Boolean> FollowLinks = Tag.from("FollowLinks", Boolean.class);
   public static final Tag<Boolean> BrowserFullScreen = Tag.from("BrowserFullScreen", Boolean.class);

--- a/testar/src/org/fruit/monkey/Main.java
+++ b/testar/src/org/fruit/monkey/Main.java
@@ -527,6 +527,15 @@ public class Main {
                 }
             }));
 
+
+			defaults.add(Pair.from(TagsForSuspiciousOracle, new ArrayList<String>() {
+				{
+					add("Title");
+					add("WebName");
+					add("WebTagName");
+				}
+			}));
+
 			defaults.add(Pair.from(FollowLinks, true));
 			defaults.add(Pair.from(BrowserFullScreen, true));
 			defaults.add(Pair.from(SwitchNewTabs, true));

--- a/testar/src/org/fruit/monkey/Settings.java
+++ b/testar/src/org/fruit/monkey/Settings.java
@@ -313,10 +313,11 @@ public class Settings extends TaggableBase implements Serializable {
 					+"#################################################################\n"
 					+"# Oracles based on suspicious titles\n"
 					+"#\n"
-					+"# Regular expression\n"
+					+"# Regular expression and Tags to apply them\n"
 					+"#################################################################\n"
 					+"\n"
 					+"SuspiciousTitles = " + Util.lineSep()
+					+"TagsForSuspiciousOracle = " + Util.lineSep()
 					+"\n"
 					+"#################################################################\n"
 					+"# Oracles based on Suspicious Outputs detected by Process Listeners\n"

--- a/testar/src/org/fruit/monkey/SettingsDialog.java
+++ b/testar/src/org/fruit/monkey/SettingsDialog.java
@@ -72,7 +72,7 @@ import static org.fruit.monkey.dialog.ToolTipTexts.*;
 public class SettingsDialog extends JFrame implements Observer {
   private static final long serialVersionUID = 5156320008281200950L;
 
-  static final String TESTAR_VERSION = "2.2.16 (27-April-2021)";
+  static final String TESTAR_VERSION = "2.2.17 (3-May-2021)";
 
   private String settingsFile;
   private Settings settings;

--- a/testar/src/org/fruit/monkey/dialog/OraclePanel.java
+++ b/testar/src/org/fruit/monkey/dialog/OraclePanel.java
@@ -1,7 +1,7 @@
 /***************************************************************************************************
  *
- * Copyright (c) 2013 - 2020 Universitat Politecnica de Valencia - www.upv.es
- * Copyright (c) 2018 - 2020 Open Universiteit - www.ou.nl
+ * Copyright (c) 2013 - 2021 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2018 - 2021 Open Universiteit - www.ou.nl
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,6 +32,8 @@
 package org.fruit.monkey.dialog;
 
 import nl.ou.testar.visualvalidation.VisualValidationSettings;
+
+import org.apache.commons.lang3.StringUtils;
 import org.fruit.monkey.ConfigTags;
 import org.fruit.monkey.Settings;
 import org.fruit.monkey.SettingsPanel;
@@ -39,137 +41,109 @@ import org.testar.settings.ExtendedSettingsFactory;
 
 import javax.swing.*;
 
-import static javax.swing.GroupLayout.DEFAULT_SIZE;
-import static javax.swing.GroupLayout.PREFERRED_SIZE;
-import static javax.swing.LayoutStyle.ComponentPlacement.RELATED;
 import static org.fruit.monkey.dialog.ToolTipTexts.enableVisualValidationTTT;
 import static org.fruit.monkey.dialog.ToolTipTexts.suspiciousTitlesTTT;
 
+import java.util.Arrays;
+
 public class OraclePanel extends SettingsPanel {
 
-	private static final long serialVersionUID = -8633257917450402330L;
+    private static final long serialVersionUID = -8633257917450402330L;
 
-	private JTextArea txtSuspTitles;
-	private JCheckBox processCheckBox;
-	private JTextArea txtProcTitles;
-	private JSpinner spnFreezeTime;
-	private JCheckBox enableVisualValidationCheckBox;
+    private JLabel suspiciousTitleLabel = new JLabel("Suspicious Titles based on Tags values (regular expression)");
+    private JLabel suspiciousTitleTagsLabel = new JLabel("Tags to apply the Suspicious Titles (semicolon to customize multiple Tags)");
+    private JLabel suspiciousProcessLabel = new JLabel("Suspicious Process Output (regular expression)");
+    private JLabel freezeTimeLabel = new JLabel("Freeze Time:");
+    private JLabel secondsLabel = new JLabel("seconds");
 
-	public OraclePanel() {
-		txtSuspTitles = new JTextArea();
-		txtSuspTitles.setLineWrap(true);
-		txtProcTitles = new JTextArea();
-		txtProcTitles.setLineWrap(true);
+    private JTextArea txtSuspTitles = new JTextArea();
+    private JTextArea txtTagsForSuspTitles = new JTextArea();
+    private JTextArea txtProcTitles = new JTextArea();
 
-		processCheckBox = new JCheckBox("Enable Process Listener");
-		processCheckBox.setBounds(10, 128, 192, 20);
-		add(processCheckBox);
+    private JCheckBox processCheckBox;
+    private JSpinner spnFreezeTime;
+    private JCheckBox enableVisualValidationCheckBox;
 
+    public OraclePanel() {
+        setLayout(null);
 
-		spnFreezeTime = new JSpinner();
-		spnFreezeTime.setModel(new SpinnerNumberModel(1.0d, 1.0d, null, 1.0d));
+        suspiciousTitleLabel.setBounds(10, 5, 600, 27);
+        suspiciousTitleLabel.setToolTipText(suspiciousTitlesTTT);
+        add(suspiciousTitleLabel);
 
-		JScrollPane suspiciousTitlePane = new JScrollPane();
-		suspiciousTitlePane.setViewportView(txtSuspTitles);
-		JScrollPane suspiciousProcessPane = new JScrollPane();
-		suspiciousProcessPane.setViewportView(txtProcTitles);
+        txtSuspTitles.setLineWrap(true);
+        JScrollPane suspTitlePane = new JScrollPane(txtSuspTitles);
+        suspTitlePane.setBounds(10, 35, 600, 100);
+        suspTitlePane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        suspTitlePane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        add(suspTitlePane);
 
+        suspiciousTitleTagsLabel.setBounds(10, 130, 600, 27);
+        add(suspiciousTitleTagsLabel);
 
-		JLabel suspiciousTitleLabel = new JLabel("Suspicious Titles:");
-		suspiciousTitleLabel.setToolTipText(suspiciousTitlesTTT);
-		JLabel suspiciousProcessLabel = new JLabel("Suspicious Process Output:");
-		JLabel freezeTimeLabel = new JLabel("Freeze Time:");
-		JLabel secondsLabel = new JLabel("seconds");
+        txtTagsForSuspTitles.setLineWrap(true);
+        JScrollPane tagsForSuspTitlesPane = new JScrollPane(txtTagsForSuspTitles);
+        tagsForSuspTitlesPane.setBounds(10, 160, 600, 50);
+        tagsForSuspTitlesPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        tagsForSuspTitlesPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        add(tagsForSuspTitlesPane);
 
-		enableVisualValidationCheckBox = new JCheckBox("Enable visual validation");
-		enableVisualValidationCheckBox.setBounds(10, 280, 180, 20);
-		enableVisualValidationCheckBox.setToolTipText(enableVisualValidationTTT);
+        suspiciousProcessLabel.setBounds(10, 220, 280, 27);
+        add(suspiciousProcessLabel);
 
-		GroupLayout gl_jPanelOracles = new GroupLayout(this);
-		this.setLayout(gl_jPanelOracles);
-		gl_jPanelOracles.setHorizontalGroup(
-				gl_jPanelOracles.createParallelGroup(GroupLayout.Alignment.LEADING)
-				.addGroup(gl_jPanelOracles.createSequentialGroup()
-						.addGap(10)
-						.addGroup(gl_jPanelOracles.createParallelGroup(GroupLayout.Alignment.LEADING, false)
-								.addGroup(gl_jPanelOracles.createSequentialGroup()
-										.addGroup(gl_jPanelOracles.createParallelGroup(GroupLayout.Alignment.LEADING)
-												.addGroup(GroupLayout.Alignment.LEADING, gl_jPanelOracles.createSequentialGroup()
-														.addComponent(enableVisualValidationCheckBox, PREFERRED_SIZE, 180, PREFERRED_SIZE)
-														.addGap(121))
-												.addGroup(gl_jPanelOracles.createSequentialGroup()
-														.addComponent(freezeTimeLabel, PREFERRED_SIZE, 92, PREFERRED_SIZE)
-														.addGap(10)
-														.addComponent(spnFreezeTime, PREFERRED_SIZE, 95, PREFERRED_SIZE)
-														.addGap(10)
-														.addComponent(secondsLabel)
-														.addGap(121))
-												.addGroup(GroupLayout.Alignment.LEADING, gl_jPanelOracles.createSequentialGroup()
-														.addComponent(suspiciousTitlePane, PREFERRED_SIZE, 600, PREFERRED_SIZE)
-														.addGap(121))
-												.addGroup(GroupLayout.Alignment.LEADING, gl_jPanelOracles.createSequentialGroup()
-														.addComponent(suspiciousProcessLabel, PREFERRED_SIZE, 200, PREFERRED_SIZE)
-														.addGap(121))
-												.addGroup(GroupLayout.Alignment.LEADING, gl_jPanelOracles.createSequentialGroup()
-														.addComponent(suspiciousProcessPane, PREFERRED_SIZE, 600, PREFERRED_SIZE)
-														.addGap(121)))
-										.addGap(23))
-								.addGroup(gl_jPanelOracles.createSequentialGroup()
-										.addPreferredGap(RELATED)
-										.addComponent(suspiciousTitleLabel, PREFERRED_SIZE, 142, PREFERRED_SIZE)
-										.addContainerGap(348, Short.MAX_VALUE))))
-				);
-		gl_jPanelOracles.setVerticalGroup(
-				gl_jPanelOracles.createParallelGroup(GroupLayout.Alignment.LEADING)
-				.addGroup(gl_jPanelOracles.createSequentialGroup()
-						.addGap(18)
-						.addComponent(suspiciousTitleLabel)
-						.addGap(240)
-						.addGroup(gl_jPanelOracles.createParallelGroup(GroupLayout.Alignment.BASELINE)
-								.addComponent(spnFreezeTime, PREFERRED_SIZE, DEFAULT_SIZE, PREFERRED_SIZE)
-								.addComponent(secondsLabel)
-								.addComponent(freezeTimeLabel))
-						.addGap(20)
-						.addComponent(enableVisualValidationCheckBox)
-						.addContainerGap(120, Short.MAX_VALUE))
-				.addGroup(gl_jPanelOracles.createSequentialGroup()
-						.addGap(160)
-						.addComponent(suspiciousProcessLabel)
-						.addGap(10)
-						.addComponent(suspiciousProcessPane, PREFERRED_SIZE, 80, PREFERRED_SIZE)
-						.addContainerGap(156, Short.MAX_VALUE))
-				.addGroup(gl_jPanelOracles.createSequentialGroup()
-						.addGap(45)
-						.addComponent(suspiciousTitlePane, PREFERRED_SIZE, 80, PREFERRED_SIZE)
-						.addContainerGap(156, Short.MAX_VALUE))
-				);
-	}
+        processCheckBox = new JCheckBox("Enable Process Listener");
+        processCheckBox.setBounds(300, 220, 200, 27);
+        add(processCheckBox);
 
-	/**
-	 * Populate Oracle Fields from Settings structure.
-	 * @param settings The settings to load.
-	 */
-	@Override
-	public void populateFrom(final Settings settings) {
-		txtSuspTitles.setText(settings.get(ConfigTags.SuspiciousTitles));
-		processCheckBox.setSelected(settings.get(ConfigTags.ProcessListenerEnabled));
-		txtProcTitles.setText(settings.get(ConfigTags.SuspiciousProcessOutput));
-		spnFreezeTime.setValue(settings.get(ConfigTags.TimeToFreeze));
-		VisualValidationSettings visualSetting = ExtendedSettingsFactory.createVisualValidationSettings();
-		enableVisualValidationCheckBox.setSelected(visualSetting.enabled);
-	}
+        txtProcTitles.setLineWrap(true);
+        JScrollPane suspiciousProcessPane = new JScrollPane(txtProcTitles);
+        suspiciousProcessPane.setBounds(10, 250, 600, 50);
+        suspiciousProcessPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        suspiciousProcessPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        add(suspiciousProcessPane);
 
-	/**
-	 * Retrieve information from the Oracle GUI.
-	 * @param settings reference to the object where the settings will be stored.
-	 */
-	@Override
-	public void extractInformation(final Settings settings) {
-		settings.set(ConfigTags.SuspiciousTitles, txtSuspTitles.getText());
-		settings.set(ConfigTags.ProcessListenerEnabled, processCheckBox.isSelected());
-		settings.set(ConfigTags.SuspiciousProcessOutput, txtProcTitles.getText());
-		settings.set(ConfigTags.TimeToFreeze, (Double) spnFreezeTime.getValue());
-		VisualValidationSettings visualSetting = ExtendedSettingsFactory.createVisualValidationSettings();
-		visualSetting.enabled = enableVisualValidationCheckBox.isSelected();
-	}
+        enableVisualValidationCheckBox = new JCheckBox("Enable visual validation");
+        enableVisualValidationCheckBox.setBounds(10, 330, 180, 27);
+        enableVisualValidationCheckBox.setToolTipText(enableVisualValidationTTT);
+        add(enableVisualValidationCheckBox);
+
+        freezeTimeLabel.setBounds(300, 330, 80, 27);
+        add(freezeTimeLabel);
+        spnFreezeTime = new JSpinner();
+        spnFreezeTime.setModel(new SpinnerNumberModel(1.0d, 1.0d, null, 1.0d));
+        spnFreezeTime.setBounds(390, 330, 50, 27);
+        add(spnFreezeTime);
+        secondsLabel.setBounds(450, 330, 50, 27);
+        add(secondsLabel);
+    }
+
+    /**
+     * Populate Oracle Fields from Settings structure.
+     * @param settings The settings to load.
+     */
+    @Override
+    public void populateFrom(final Settings settings) {
+        txtSuspTitles.setText(settings.get(ConfigTags.SuspiciousTitles));
+        txtTagsForSuspTitles.setText(StringUtils.join(settings.get(ConfigTags.TagsForSuspiciousOracle), ";"));
+        processCheckBox.setSelected(settings.get(ConfigTags.ProcessListenerEnabled));
+        txtProcTitles.setText(settings.get(ConfigTags.SuspiciousProcessOutput));
+        spnFreezeTime.setValue(settings.get(ConfigTags.TimeToFreeze));
+        VisualValidationSettings visualSetting = ExtendedSettingsFactory.createVisualValidationSettings();
+        enableVisualValidationCheckBox.setSelected(visualSetting.enabled);
+    }
+
+    /**
+     * Retrieve information from the Oracle GUI.
+     * @param settings reference to the object where the settings will be stored.
+     */
+    @Override
+    public void extractInformation(final Settings settings) {
+        settings.set(ConfigTags.SuspiciousTitles, txtSuspTitles.getText());
+        settings.set(ConfigTags.TagsForSuspiciousOracle, Arrays.asList(txtTagsForSuspTitles.getText().split(";")));
+        settings.set(ConfigTags.ProcessListenerEnabled, processCheckBox.isSelected());
+        settings.set(ConfigTags.SuspiciousProcessOutput, txtProcTitles.getText());
+        settings.set(ConfigTags.TimeToFreeze, (Double) spnFreezeTime.getValue());
+        VisualValidationSettings visualSetting = ExtendedSettingsFactory.createVisualValidationSettings();
+        visualSetting.enabled = enableVisualValidationCheckBox.isSelected();
+    }
 }

--- a/testar/src/org/testar/protocols/GenericUtilsProtocol.java
+++ b/testar/src/org/testar/protocols/GenericUtilsProtocol.java
@@ -301,6 +301,7 @@ public class GenericUtilsProtocol extends ClickFilterLayerProtocol {
             for(Tag tag : w.tags()){
                 if(tag.name().equals(tagToFilter)){
                     tagValue = w.get(tag, "");
+                    break;
                     //System.out.println("DEBUG: tag found, "+tagToFilter+"="+tagValue);
                 }
             }


### PR DESCRIPTION
TESTAR was cheking for suspicious titles only in the Title and ValuePattern tags.
Now there is a new setting `TagsForSuspiciousOracle` where multiple tag names can be put and the same RegEx is used to check all of them.

- TESTAR Oracle dialog panel modified
- gradle CI tests modified to validate this new feature