### PR TITLE
Added validity check for negative coordinates (out of screen).

### DIFF
--- a/core/src/es/upv/staq/testar/ProtocolUtil.java
+++ b/core/src/es/upv/staq/testar/ProtocolUtil.java
@@ -312,7 +312,7 @@ public class ProtocolUtil {
 	private static Rect calculateRectOfSUT(State state, Rect viewPortRect) {
 		Rect rectSUT = viewPortRect;
 		for (Widget w : state) {
-			if(w.get(Tags.Shape, null) != null && !w.get(Tags.Role, Roles.Process).equals(Roles.Process)) {
+			if(w.get(Tags.Enabled, false) && w.get(Tags.Shape, null) != null && !w.get(Tags.Role, Roles.Process).equals(Roles.Process)) {
 				double xPos = w.get(Tags.Shape).x();
 				double yPos = w.get(Tags.Shape).y();
 				// Minus values are invalid, change them to 0

--- a/core/src/es/upv/staq/testar/ProtocolUtil.java
+++ b/core/src/es/upv/staq/testar/ProtocolUtil.java
@@ -313,7 +313,27 @@ public class ProtocolUtil {
 		Rect rectSUT = viewPortRect;
 		for (Widget w : state) {
 			if(w.get(Tags.Shape, null) != null && !w.get(Tags.Role, Roles.Process).equals(Roles.Process)) {
-				Rect widgetRect = Rect.from(w.get(Tags.Shape).x(), w.get(Tags.Shape).y(), w.get(Tags.Shape).width(), w.get(Tags.Shape).height());
+				double xPos = w.get(Tags.Shape).x();
+				double yPos = w.get(Tags.Shape).y();
+				// Minus values are invalid, change them to 0
+				double width = Math.max(w.get(Tags.Shape).width(), 0d);
+				double height = Math.max(w.get(Tags.Shape).height(), 0d);
+				// Widget x coordinate can be out of screen
+				if(xPos < 0d) {
+					width -= xPos;
+					xPos = 0d;
+				}
+				// Widget y coordinate can be out of screen
+				if(yPos < 0d) {
+					height -= yPos;
+					yPos = 0d;
+				}
+				// Validate width and height
+				if(width <= 0d || height <= 0d) {
+					return viewPortRect;
+				}
+
+				Rect widgetRect = Rect.from(xPos, yPos, width, height);
 				if(!Rect.contains(rectSUT, widgetRect)) {
 					rectSUT = Rect.union(rectSUT, widgetRect);
 				}


### PR DESCRIPTION
Sometimes when application x (at least file explorer and notepad) get minimized, children object coordinates can get invalid values (~ -30000, -30000). These values needs to be excluded.

Minus coordinates can be normal behavior as well, when window is slightly over left side of screen. So they cannot be excluded "blindly". My proposal moves x coordinate from minus to zero and removes out of screen width -> Black bar gets removed from left side and huge minus values gets excluded.

![old-behavior](https://user-images.githubusercontent.com/85728158/133964777-b98ee25f-517a-4433-9472-98975fcdcb2a.png)
![new-behavior](https://user-images.githubusercontent.com/85728158/133964773-cd106030-bfe5-4591-ae0e-954a0b7cac37.png)
