### PR TITLE
Java 17 support and GUI GitHub Actions test

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,13 @@ jobs:
     
     - name: Build TESTAR with Gradle
       run: ./gradlew build
-    
+
+    - name: Save JUnit test results
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: saveJunitTests-artifact
+        path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/reports/tests
+
     - name: Prepare installed distribution of TESTAR with Gradle
       run: ./gradlew installDist
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -158,6 +158,12 @@ jobs:
     - name: Run TESTAR dialog
       run: ./gradlew runTestRunGUI
 
+    - name: Run desktop_generic protocol using specific filtering and detect a SuspiciousTitle with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle
+
+    - name: Run webdriver to login in parabank app
+      run: ./gradlew runTestWebdriverParabankLogin
+
   windows_java_17:
     runs-on: windows-latest
     timeout-minutes: 10
@@ -183,6 +189,12 @@ jobs:
 
     - name: Run TESTAR dialog
       run: ./gradlew runTestRunGUI
+
+    - name: Run desktop_generic protocol using specific filtering and detect a SuspiciousTitle with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle
+
+    - name: Run webdriver to login in parabank app
+      run: ./gradlew runTestWebdriverParabankLogin
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,12 +5,12 @@ name: TESTAR CI - build with Gradle
 
 on:
   push:
-    branches: [ master, master_gradle_workflow ]
+    branches: [ master, master_gradle_workflow, master_workflow ]
   pull_request:
     branches: [ master ]
 
 jobs:
-  windows:
+  windows_java_8:
     runs-on: windows-latest
     timeout-minutes: 30
 
@@ -32,7 +32,10 @@ jobs:
     
     - name: Prepare installed distribution of TESTAR with Gradle
       run: ./gradlew installDist
-    
+
+    - name: Run TESTAR dialog
+      run: ./gradlew runTestRunGUI
+
     - name: Run desktop_generic protocol with TESTAR using COMMAND_LINE
       run: ./gradlew runTestDesktopGenericCommandLineOk
     - name: Save runTestDesktopGenericCommandLineOk HTML report artifact
@@ -128,6 +131,58 @@ jobs:
       with:
         name: runTestWebdriverUnreplayable-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/webdriver_unreplayable
+
+  windows_java_11:
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Java 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    
+    - name: Prepare TESTAR protocols
+      run: ./gradlew init_workflow_test
+    
+    - name: Build TESTAR with Gradle
+      run: ./gradlew build
+    
+    - name: Prepare installed distribution of TESTAR with Gradle
+      run: ./gradlew installDist
+
+    - name: Run TESTAR dialog
+      run: ./gradlew runTestRunGUI
+
+  windows_java_17:
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Java 17
+      uses: actions/setup-java@v1
+      with:
+        java-version: 17
+    
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    
+    - name: Prepare TESTAR protocols
+      run: ./gradlew init_workflow_test
+    
+    - name: Build TESTAR with Gradle
+      run: ./gradlew build
+    
+    - name: Prepare installed distribution of TESTAR with Gradle
+      run: ./gradlew installDist
+
+    - name: Run TESTAR dialog
+      run: ./gradlew runTestRunGUI
 
   linux:
     runs-on: ubuntu-latest

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip

--- a/testar/build.gradle
+++ b/testar/build.gradle
@@ -206,6 +206,26 @@ task init_workflow_test(type: Copy) {
     into 'target/scripts/settings'
 }
 
+// Execute a protocol to test that the GUI starts correctly
+task runTestRunGUI(type: Exec, dependsOn:'installDist') {
+	// Read command line output
+    standardOutput = new ByteArrayOutputStream()
+    group = 'test_testar_workflow'
+    description ='runTestRunGUI'
+    workingDir 'target/install/testar/bin'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_run_gui AlwaysCompile=true ShowVisualSettingsDialogOnStartup=false'
+    doLast {
+        String output = standardOutput.toString()
+
+		// Check that output contains No problem detected. message to verify the correct execution
+        if(output.readLines().any{line->line.contains("Saved current settings")}) {
+            println "\n${output} \nTESTAR GUI launched successfully"
+        } else {
+            throw new GradleException("\n${output} \nERROR: Launching TESTAR GUI")
+        }
+    }
+}
+
 // Default COMMAND_LINE execution to run Notepad, execute 2 actions and verdict should be OK
 task runTestDesktopGenericCommandLineOk(type: Exec, dependsOn:'installDist') {
 	// Read command line output

--- a/testar/build.gradle
+++ b/testar/build.gradle
@@ -93,6 +93,9 @@ dependencies {
     implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.1.3'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+    // Use jaxb 2.3.1 to fix a Java17 issue with the version 2.3.0 included in the orientdb server dependencies
+    implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
+    implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.1'
     implementation group: 'com.orientechnologies', name: 'orientdb-graphdb', version: '3.0.34'
 }
 

--- a/testar/resources/workflow/settings/test_gradle_workflow_run_gui/Protocol_test_gradle_workflow_run_gui.java
+++ b/testar/resources/workflow/settings/test_gradle_workflow_run_gui/Protocol_test_gradle_workflow_run_gui.java
@@ -1,0 +1,108 @@
+/***************************************************************************************************
+ *
+ * Copyright (c) 2020 - 2022 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2020 - 2022 Open Universiteit - www.ou.nl
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************************************/
+
+import java.awt.event.WindowEvent;
+import java.io.IOException;
+import org.testar.monkey.Main;
+import org.testar.monkey.Settings;
+import org.testar.monkey.Util;
+import org.testar.protocols.DesktopProtocol;
+import org.testar.settingsdialog.SettingsDialog;
+
+/**
+ * This protocol is used to test TESTAR by executing a gradle CI workflow. 
+ * 
+ * Test that the GUI runs with different Java versions. 
+ * 
+ * ".github/workflows/gradle.yml"
+ */
+public class Protocol_test_gradle_workflow_run_gui extends DesktopProtocol {
+
+	@Override
+	protected void initialize(Settings settings){
+		super.initialize(settings);
+		String testSettingsFileName = Main.getTestSettingsFile();
+		SettingsDialog dialog = null;
+		try {
+			dialog = new SettingsDialog();
+		} catch (IOException ioe) {
+			ioe.printStackTrace();
+		}
+
+		// Create a thread to run TESTAR dialog
+		MyThread guiThread = new MyThread("GUIThread", dialog, settings, testSettingsFileName);
+
+		// Wait 10 second so the GUIThread will run the dialog, then close the dialog JFrame
+		Util.pause(10);
+		// Then force to close the dialog JFrame
+		dialog.dispatchEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSING));
+
+		try {
+			guiThread.t.join();
+		} catch (InterruptedException e) {
+			System.out.println("Thread Interrupted : " + guiThread.name);
+		}
+
+		System.out.println("Thread Finished : " + guiThread.name);
+
+		// Force TESTAR to finish the execution
+		this.mode = Modes.Quit;
+	}
+
+	class MyThread implements Runnable {
+		String name;
+		Thread t;
+		SettingsDialog dialog;
+		Settings guiSettings;
+		String testSettingsFileName;
+
+		MyThread(String threadName, SettingsDialog dialog, Settings guiSettings, String testSettingsFileName) {
+			name = threadName;
+			t = new Thread(this, name);
+			this.dialog = dialog;
+			this.guiSettings = guiSettings;
+			this.testSettingsFileName = testSettingsFileName;
+			t.start();
+		}
+
+		public void run() {
+			try {
+				System.out.println("Thread: Run GUI dialog");
+				dialog.run(this.guiSettings, this.testSettingsFileName);
+				System.out.println("Thread: GUI dialog finished");
+				Thread.sleep(5000);
+			} catch (InterruptedException e) {
+				System.out.println(name + " interrupted.");
+			}
+			System.out.println(name + " exiting...");
+		}
+	}
+
+}

--- a/testar/resources/workflow/settings/test_gradle_workflow_run_gui/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_run_gui/test.settings
@@ -1,0 +1,138 @@
+#################################################################
+# TESTAR mode
+#
+# Set the mode you want TESTAR to start in: Spy, Generate, Replay
+#################################################################
+
+Mode = Generate
+
+#################################################################
+# Connect to the System Under Test (SUT)
+#
+# Indicate how you want to connect to the SUT:
+#
+# SUTCONNECTOR = COMMAND_LINE, SUTConnectorValue property must be a command line that
+# starts the SUT.
+# It should work from a Command Prompt terminal window (e.g. java - jar SUTs/calc.jar ).
+# For web applications, follow the next format: web_browser_path SUT_URL.
+#
+# SUTCONNECTOR = SUT_WINDOW_TITLE, then SUTConnectorValue property must be the title displayed
+# in the SUT main window. The SUT must be manually started and closed.
+#
+# SUTCONNECTOR = SUT_PROCESS_NAME: SUTConnectorValue property must be the process name of the SUT.
+# The SUT must be manually started and closed.
+#################################################################
+SUTConnector = COMMAND_LINE
+SUTConnectorValue = c:\\windows\\system32\\notepad.exe
+
+#################################################################
+# Sequences
+#
+# Number of sequences and the length of these sequences
+#################################################################
+
+Sequences = 1
+SequenceLength = 1
+
+#################################################################
+# Oracles based on suspicious titles
+#
+# Regular expression
+#################################################################
+
+SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+
+#################################################################
+# Oracles based on Suspicious Outputs detected by Process Listeners
+#
+# Requires ProcessListenerEnabled
+# (Only available for desktop applications through COMMAND_LINE)
+#
+# Regular expression SuspiciousProcessOutput contains the specification
+# of what is considered to be suspicious output.
+#################################################################
+
+ProcessListenerEnabled = false
+SuspiciousProcessOutput = .*[eE]rror.*|.*[eE]xcep[ct]i[o?]n.*
+
+#################################################################
+# Process Logs
+#
+# Requires ProcessListenerEnabled
+# (Only available for desktop applications through COMMAND_LINE)
+#
+# Allow TESTAR to store execution logs coming from the processes.
+# You can use the regular expression ProcessLogs below to filter 
+# the logs. Use .*.* if you want to store all the outputs of the 
+# process.
+#################################################################
+
+ProcessLogs = .*.*
+
+#################################################################
+# Actionfilter
+#
+# Regular expression. More filters can be added in Spy mode,
+# these will be added to the protocol_filter.xml file.
+#################################################################
+
+ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir.*|.*[eE]xit.*|.*[mM]inimizar.*|.*[mM]inimi[zs]e.*|.*[gG]uardar.*|.*[sS]ave.*|.*[iI]mprimir.*|.*[pP]rint.*
+
+#################################################################
+# Processfilter
+#
+# Regular expression. Kill the processes that your SUT can start up
+# but that you do not want to test.
+#################################################################
+
+SUTProcesses =
+
+#################################################################
+# Protocolclass
+#
+# Indicate the location of the protocol class for your specific SUT.
+#################################################################
+
+ProtocolClass = test_gradle_workflow_run_gui/Protocol_test_gradle_workflow_run_gui
+
+#################################################################
+# State identifier attributes
+#
+# Specify the widget attributes that you wish to use in constructing
+# the widget and state hash strings. Use a comma separated list.
+#################################################################
+AbstractStateAttributes = WidgetControlType
+
+#################################################################
+# Other more advanced settings
+#################################################################
+
+ProcessesToKillDuringTest =
+OutputDir = ./output
+PathToReplaySequence = ./output/temp
+TempDir = ./output/temp
+UseRecordedActionDurationAndWaitTimeDuringReplay = false
+ForceForeground = true
+LogLevel = 1
+ExecuteActions = true
+FaultThreshold = 0.000000001
+DrawWidgetUnderCursor = true
+MyClassPath = ./settings
+OnlySaveFaultySequences = false
+ActionDuration = 0.1
+ShowVisualSettingsDialogOnStartup = false
+ReplayRetryTime = 30.0
+Delete =
+MaxTime = 3.1536E7
+ShowSettingsAfterTest = true
+TimeToWaitAfterAction = 0.1
+StartupTime = 10.0
+DrawWidgetInfo = false
+TimeToFreeze = 30.0
+StopGenerationOnFault = true
+CopyFromTo =
+VisualizeActions = false
+VisualizeSelectedAction = true
+TestGenerator = random
+MaxReward = 9999999
+Discount = .95


### PR DESCRIPTION
- Upgrade gradle wrapper to 7.3 to support Java 17
- Upgrade jaxb dependencies to 2.3.1 to fix a XML framework issue
- Save JUnit test results as GitHub Actions artifact
- Add a new GitHub Actions test to check that TESTAR dialog is executed correctly
- Add new GitHub Actions environments with Java 11 and 17