### PR TITLE
Refactor action implementation#326

### DIFF
--- a/testar/resources/settings/android_generic/Protocol_android_generic.java
+++ b/testar/resources/settings/android_generic/Protocol_android_generic.java
@@ -282,19 +282,12 @@ public class Protocol_android_generic extends AndroidProtocol {
 	 */
 	@Override
 	protected Action selectAction(State state, Set<Action> actions){
-
-		Action retAction = stateModelManager.getAbstractActionToExecute(actions);
+		return super.selectAction(state, actions);
 
 		// Uncomment the next line to use the Qlearning action selector
 //			System.out.println("Q-learning action selector");
 //			retAction = actionSelector.selectAction(state,actions);
-		if(retAction==null) {
-			System.out.println("State model based action selection did not find an action. Using random action selection.");
-			// if state model fails, use random (default would call preSelectAction() again, causing double actions HTML report):
-			retAction = RandomActionSelector.selectAction(actions);
-		}
 
-		return retAction;
 	}
 
 	private boolean notBanned(Widget w) {

--- a/testar/resources/settings/desktop_generic_all_features/Protocol_desktop_generic_all_features.java
+++ b/testar/resources/settings/desktop_generic_all_features/Protocol_desktop_generic_all_features.java
@@ -194,18 +194,7 @@ public class Protocol_desktop_generic_all_features extends DesktopProtocol {
 	protected Action selectAction(State state, Set<Action> actions){
 		//Call the preSelectAction method from the DefaultProtocol so that, if necessary,
 		//unwanted processes are killed and SUT is put into foreground.
-		Action retAction = super.selectAction(state, actions);
-		if (retAction == null) {
-			//if no preSelected actions are needed, then implement your own strategy
-			//using the action selector of the state model:
-			retAction = stateModelManager.getAbstractActionToExecute(actions);
-		}
-		if(retAction==null) {
-			System.out.println("State model based action selection did not find an action. Using default action selection.");
-			//if your own action selection algorithm fails to find an action, use the default random action selection:
-			retAction = super.selectAction(state, actions);
-		}
-		return retAction;
+		return super.selectAction(state, actions);
 	}
 
 	/**

--- a/testar/resources/settings/desktop_generic_statemodel/Protocol_desktop_generic_statemodel.java
+++ b/testar/resources/settings/desktop_generic_statemodel/Protocol_desktop_generic_statemodel.java
@@ -92,21 +92,9 @@ public class Protocol_desktop_generic_statemodel extends DesktopProtocol {
 	 */
 	@Override
 	protected Action selectAction(State state, Set<Action> actions){
-
 		//Call the preSelectAction method from the AbstractProtocol so that, if necessary,
 		//unwanted processes are killed and SUT is put into foreground.
-		Action retAction = super.selectAction(state, actions);
-		if (retAction== null) {
-			//if no preSelected actions are needed, then implement your own action selection strategy
-			//using the action selector of the state model:
-			retAction = stateModelManager.getAbstractActionToExecute(actions);
-		}
-		if(retAction==null) {
-			System.out.println("State model based action selection did not find an action. Using random action selection.");
-			// if state model fails, use random (default would call preSelectAction() again, causing double actions HTML report):
-			retAction = RandomActionSelector.selectAction(actions);
-		}
-		return retAction;
+		return super.selectAction(state, actions);
 	}
 
 }

--- a/testar/resources/settings/desktop_qlearning/Protocol_desktop_qlearning.java
+++ b/testar/resources/settings/desktop_qlearning/Protocol_desktop_qlearning.java
@@ -114,11 +114,12 @@ public class Protocol_desktop_qlearning extends DesktopProtocol {
 	protected Action selectAction(State state, Set<Action> actions){
 		//Call the preSelectAction method from the DefaultProtocol so that, if necessary,
 		//unwanted processes are killed and SUT is put into foreground.
-		Action retAction = super.selectAction(state, actions);
+		//if no preSelected actions are needed, then implement your own action selection strategy
+		// Maintaining memory of visited states and selected actions, and selecting randomly from unvisited actions:
+		Action retAction = actionSelector.selectAction(state,actions);
+
 		if (retAction== null) {
-			//if no preSelected actions are needed, then implement your own action selection strategy
-			// Maintaining memory of visited states and selected actions, and selecting randomly from unvisited actions:
-			retAction = actionSelector.selectAction(state,actions);
+			retAction = super.selectAction(state, actions);
 		}
 		return retAction;
 	}

--- a/testar/resources/settings/desktop_simple_stategraph/Protocol_desktop_simple_stategraph.java
+++ b/testar/resources/settings/desktop_simple_stategraph/Protocol_desktop_simple_stategraph.java
@@ -104,11 +104,11 @@ public class Protocol_desktop_simple_stategraph extends DesktopProtocol {
 		}
 		//Call the preSelectAction method from the AbstractProtocol so that, if necessary,
 		//unwanted processes are killed and SUT is put into foreground.
-		Action retAction = super.selectAction(state, actions);
+		//if no preSelected actions are needed, then implement your own action selection strategy
+		// Maintaining memory of visited states and selected actions, and selecting randomly from unvisited actions:
+		Action retAction = stateGraphWithVisitedActions.selectAction(state,actions);
 		if (retAction== null) {
-			//if no preSelected actions are needed, then implement your own action selection strategy
-			// Maintaining memory of visited states and selected actions, and selecting randomly from unvisited actions:
-			retAction = stateGraphWithVisitedActions.selectAction(state,actions);
+			retAction = super.selectAction(state, actions);
 		}
 		return retAction;
 	}

--- a/testar/resources/settings/desktop_simple_stategraph_eye/Protocol_desktop_simple_stategraph_eye.java
+++ b/testar/resources/settings/desktop_simple_stategraph_eye/Protocol_desktop_simple_stategraph_eye.java
@@ -132,11 +132,11 @@ public class Protocol_desktop_simple_stategraph_eye extends DesktopProtocol {
 		}
 		//Call the preSelectAction method from the DefaultProtocol so that, if necessary,
 		//unwanted processes are killed and SUT is put into foreground.
-		Action retAction = super.selectAction(state, actions);
+		//if no preSelected actions are needed, then implement your own action selection strategy
+		// Maintaining memory of visited states and selected actions, and selecting randomly from unvisited actions:
+		Action retAction = stateGraphWithVisitedActions.selectAction(state,actions);
 		if (retAction== null) {
-			//if no preSelected actions are needed, then implement your own action selection strategy
-			// Maintaining memory of visited states and selected actions, and selecting randomly from unvisited actions:
-			retAction = stateGraphWithVisitedActions.selectAction(state,actions);
+			retAction = super.selectAction(state, actions);
 		}
 		return retAction;
 	}

--- a/testar/resources/settings/desktop_simple_stategraph_sikulix/Protocol_desktop_simple_stategraph_sikulix.java
+++ b/testar/resources/settings/desktop_simple_stategraph_sikulix/Protocol_desktop_simple_stategraph_sikulix.java
@@ -128,11 +128,11 @@ public class Protocol_desktop_simple_stategraph_sikulix extends DesktopProtocol 
 		}
 		//Call the preSelectAction method from the DefaultProtocol so that, if necessary,
 		//unwanted processes are killed and SUT is put into foreground.
-		Action retAction = super.selectAction(state, actions);
+		//if no preSelected actions are needed, then implement your own action selection strategy
+		// Maintaining memory of visited states and selected actions, and selecting randomly from unvisited actions:
+		Action retAction = stateGraphWithVisitedActions.selectAction(state,actions);
 		if (retAction== null) {
-			//if no preSelected actions are needed, then implement your own action selection strategy
-			// Maintaining memory of visited states and selected actions, and selecting randomly from unvisited actions:
-			retAction = stateGraphWithVisitedActions.selectAction(state,actions);
+			retAction = super.selectAction(state, actions);
 		}
 		return retAction;
 	}

--- a/testar/resources/settings/webdriver_statemodel/Protocol_webdriver_statemodel.java
+++ b/testar/resources/settings/webdriver_statemodel/Protocol_webdriver_statemodel.java
@@ -161,18 +161,7 @@ public class Protocol_webdriver_statemodel extends WebdriverProtocol {
 
 		//Call the preSelectAction method from the AbstractProtocol so that, if necessary,
 		//unwanted processes are killed and SUT is put into foreground.
-		Action retAction = super.selectAction(state, actions);
-		if (retAction== null) {
-			//if no preSelected actions are needed, then implement your own action selection strategy
-			//using the action selector of the state model:
-			retAction = stateModelManager.getAbstractActionToExecute(actions);
-		}
-		if(retAction==null) {
-			System.out.println("State model based action selection did not find an action. Using random action selection.");
-			// if state model fails, using random:
-			retAction = RandomActionSelector.selectAction(actions);
-		}
-		return retAction;
+		return super.selectAction(state, actions);
 	}
 
 }

--- a/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic_custom_abstraction/Protocol_test_gradle_workflow_desktop_generic_custom_abstraction.java
+++ b/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic_custom_abstraction/Protocol_test_gradle_workflow_desktop_generic_custom_abstraction.java
@@ -151,21 +151,9 @@ public class Protocol_test_gradle_workflow_desktop_generic_custom_abstraction ex
 
     @Override
     protected Action selectAction(State state, Set<Action> actions){
-
-        //Call the preSelectAction method from the AbstractProtocol so that, if necessary,
-        //unwanted processes are killed and SUT is put into foreground.
-        Action retAction = super.selectAction(state, actions);
-        if (retAction== null) {
-            //if no preSelected actions are needed, then implement your own action selection strategy
-            //using the action selector of the state model:
-            retAction = stateModelManager.getAbstractActionToExecute(actions);
-        }
-        if(retAction==null) {
-            System.out.println("State model based action selection did not find an action. Using random action selection.");
-            // if state model fails, use random (default would call preSelectAction() again, causing double actions HTML report):
-            retAction = RandomActionSelector.selectAction(actions);
-        }
-        return retAction;
+    	//The default select action mechanism tries to use the state model action selector. 
+    	//If the state model is not enabled, it returns a random action.
+    	return super.selectAction(state, actions);
     }
 
     @Override

--- a/testar/src/org/testar/monkey/DefaultProtocol.java
+++ b/testar/src/org/testar/monkey/DefaultProtocol.java
@@ -1064,21 +1064,21 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 	}
 
 	/**
-	 * Returns the next action that will be selected. If unwanted processes need to be killed, the action kills them. If the SUT needs
-	 * to be put in the foreground, then the action is putting it in the foreground. Otherwise the action is selected according to
-	 * action selection mechanism selected.
-	 * @param state
-	 * @param actions
-	 * @return
+	 * Select one of the available actions using the action selection algorithm of your choice. 
+	 * The default select action mechanism tries to use the state model action selector. 
+	 * If the state model is not enabled, it returns a random action. 
+	 *
+	 * @param state the SUT's current state
+	 * @param actions the set of derived actions
+	 * @return  the selected action
 	 */
 	protected Action selectAction(State state, Set<Action> actions){
 		Assert.isTrue(actions != null && !actions.isEmpty());
 
 		//Using the action selector of the state model:
 		Action retAction = stateModelManager.getAbstractActionToExecute(actions);
-		// If state model fails, use random:
+		// If state model is not enabled, use random:
 		if (retAction == null) {
-			System.out.println("State model based action selection did not find an action. Using random action selection.");
 			return RandomActionSelector.selectAction(actions);
 		}
 		return retAction;

--- a/testar/src/org/testar/monkey/DefaultProtocol.java
+++ b/testar/src/org/testar/monkey/DefaultProtocol.java
@@ -1073,7 +1073,15 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 	 */
 	protected Action selectAction(State state, Set<Action> actions){
 		Assert.isTrue(actions != null && !actions.isEmpty());
-		return RandomActionSelector.selectAction(actions);
+
+		//Using the action selector of the state model:
+		Action retAction = stateModelManager.getAbstractActionToExecute(actions);
+		// If state model fails, use random:
+		if (retAction == null) {
+			System.out.println("State model based action selection did not find an action. Using random action selection.");
+			return RandomActionSelector.selectAction(actions);
+		}
+		return retAction;
 	}
 
 	protected String getRandomText(Widget w){

--- a/testar/workflow.gradle
+++ b/testar/workflow.gradle
@@ -242,6 +242,14 @@ task runTestDesktopGenericStateModel(type: Exec, dependsOn: createDatabaseOrient
     doLast {
         String output = standardOutput.toString()
 
+        // Check that State Model was calculating the execution path
+        // This is not only to check that the model is enabled, but also to check the model action selection mechanism
+        if(output.readLines().any{line->line.contains("New execution path")}) {
+            println "\n${output} \nTESTAR State Model is enabled and calculates the execution path"
+        } else {
+            throw new GradleException("\n${output} \nERROR: TESTAR State Model does NOT calculate the execution path")
+        }
+
         // Check that output contains 3 abstract states in the State Model inference
         if(output.readLines().any{line->line.contains("3 abstract states in the model")}) {
             println "\n${output} \nTESTAR State Model has been inferred sucessfully"


### PR DESCRIPTION
Default protocol now invokes the state model action selector, otherwise, a random action is generated.

Protocol subclasses were updated consequently:
- Protocols already calling state model and random: delegate select action method to the default protocol.
- Protocols with specific action selectors: first invoking action selector, then default protocol action selector.
