### PR TITLE
ConfigTags and protocol changes for the HandsOn guide

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -58,36 +58,36 @@ jobs:
         name: runTestDesktopGenericMultiTags-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_multitags
 
-    - name: Run desktop_generic protocol that contains SuspiciousTitle with TESTAR
-      run: ./gradlew runTestDesktopGenericCommandLineSuspiciousTitle
-    - name: Save runTestDesktopGenericCommandLineSuspiciousTitle HTML report artifact
+    - name: Run desktop_generic protocol that contains SuspiciousTag with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSuspiciousTag
+    - name: Save runTestDesktopGenericCommandLineSuspiciousTag HTML report artifact
       uses: actions/upload-artifact@v2.2.4
       with:
-        name: runTestDesktopGenericCommandLineSuspiciousTitle-artifact
+        name: runTestDesktopGenericCommandLineSuspiciousTag-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_command_and_suspicious
     
-    - name: Run desktop_generic protocol using specific filtering and detect a SuspiciousTitle with TESTAR
-      run: ./gradlew runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle
-    - name: Save runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle HTML report artifact
+    - name: Run desktop_generic protocol using specific filtering and detect a SuspiciousTag with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSettingsFilterSuspiciousTag
+    - name: Save runTestDesktopGenericCommandLineSettingsFilterSuspiciousTag HTML report artifact
       uses: actions/upload-artifact@v2.2.4
       with:
-        name: runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle-artifact
+        name: runTestDesktopGenericCommandLineSettingsFilterSuspiciousTag-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_command_settings_filter_and_suspicious
     
-    - name: Run desktop_generic protocol but connect using SUT_PROCESS_NAME and detect SuspiciousTitle
-      run: ./gradlew runTestDesktopGenericProcessNameSuspiciousTitle
-    - name: Save runTestDesktopGenericProcessNameSuspiciousTitle HTML report artifact
+    - name: Run desktop_generic protocol but connect using SUT_PROCESS_NAME and detect SuspiciousTag
+      run: ./gradlew runTestDesktopGenericProcessNameSuspiciousTag
+    - name: Save runTestDesktopGenericProcessNameSuspiciousTag HTML report artifact
       uses: actions/upload-artifact@v2.2.4
       with:
-        name: runTestDesktopGenericProcessNameSuspiciousTitle-artifact
+        name: runTestDesktopGenericProcessNameSuspiciousTag-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_process_and_suspicious
     
-    - name: Run desktop_generic protocol but connect using SUT_WINDOW_TITLE and detect SuspiciousTitle
-      run: ./gradlew runTestDesktopGenericTitleNameSuspiciousTitle
-    - name: Save runTestDesktopGenericTitleNameSuspiciousTitle HTML report artifact
+    - name: Run desktop_generic protocol but connect using SUT_WINDOW_TITLE and detect SuspiciousTag
+      run: ./gradlew runTestDesktopGenericTitleNameSuspiciousTag
+    - name: Save runTestDesktopGenericTitleNameSuspiciousTag HTML report artifact
       uses: actions/upload-artifact@v2.2.4
       with:
-        name: runTestDesktopGenericTitleNameSuspiciousTitle-artifact
+        name: runTestDesktopGenericTitleNameSuspiciousTag-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_title_and_suspicious
     
     - name: Run desktop_generic with OrientDB to infer a TESTAR State Model
@@ -106,12 +106,12 @@ jobs:
         name: runTestDesktopGenericStateModelCustomAbstraction-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/notepad_state_model_custom
     
-    - name: Run webdriver protocol and detect SuspiciousTitle
-      run: ./gradlew runTestWebdriverSuspiciousTitle
-    - name: Save runTestWebdriverSuspiciousTitle HTML report artifact
+    - name: Run webdriver protocol and detect SuspiciousTag
+      run: ./gradlew runTestWebdriverSuspiciousTag
+    - name: Save runTestWebdriverSuspiciousTag HTML report artifact
       uses: actions/upload-artifact@v2.2.4
       with:
-        name: runTestWebdriverSuspiciousTitle-artifact
+        name: runTestWebdriverSuspiciousTag-artifact
         path: D:/a/TESTAR_dev/TESTAR_dev/testar/target/install/testar/bin/webdriver_and_suspicious
     
     - name: Run webdriver to login in parabank and detect browser console error
@@ -178,17 +178,17 @@ jobs:
     - name: Run desktop_generic protocol with TESTAR to test waitAndLeftClickWidgetWithMatchingTags feature
       run: ./gradlew runTestDesktopGenericMultiTags
 
-    - name: Run desktop_generic protocol that contains SuspiciousTitle with TESTAR
-      run: ./gradlew runTestDesktopGenericCommandLineSuspiciousTitle
+    - name: Run desktop_generic protocol that contains SuspiciousTag with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSuspiciousTag
     
-    - name: Run desktop_generic protocol using specific filtering and detect a SuspiciousTitle with TESTAR
-      run: ./gradlew runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle
+    - name: Run desktop_generic protocol using specific filtering and detect a SuspiciousTag with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSettingsFilterSuspiciousTag
     
-    - name: Run desktop_generic protocol but connect using SUT_PROCESS_NAME and detect SuspiciousTitle
-      run: ./gradlew runTestDesktopGenericProcessNameSuspiciousTitle
+    - name: Run desktop_generic protocol but connect using SUT_PROCESS_NAME and detect SuspiciousTag
+      run: ./gradlew runTestDesktopGenericProcessNameSuspiciousTag
     
-    - name: Run desktop_generic protocol but connect using SUT_WINDOW_TITLE and detect SuspiciousTitle
-      run: ./gradlew runTestDesktopGenericTitleNameSuspiciousTitle
+    - name: Run desktop_generic protocol but connect using SUT_WINDOW_TITLE and detect SuspiciousTag
+      run: ./gradlew runTestDesktopGenericTitleNameSuspiciousTag
     
     - name: Run desktop_generic with OrientDB to infer a TESTAR State Model
       run: ./gradlew runTestDesktopGenericStateModel
@@ -196,8 +196,8 @@ jobs:
     - name: Run desktop_generic doing a customization in the AbstractIDCustom identifer
       run: ./gradlew runTestDesktopGenericStateModelCustomAbstraction
     
-    - name: Run webdriver protocol and detect SuspiciousTitle
-      run: ./gradlew runTestWebdriverSuspiciousTitle
+    - name: Run webdriver protocol and detect SuspiciousTag
+      run: ./gradlew runTestWebdriverSuspiciousTag
     
     - name: Run webdriver to login in parabank and detect browser console error
       run: ./gradlew runTestWebdriverParabankLoginAndConsoleError
@@ -243,17 +243,17 @@ jobs:
     - name: Run desktop_generic protocol with TESTAR to test waitAndLeftClickWidgetWithMatchingTags feature
       run: ./gradlew runTestDesktopGenericMultiTags
 
-    - name: Run desktop_generic protocol that contains SuspiciousTitle with TESTAR
-      run: ./gradlew runTestDesktopGenericCommandLineSuspiciousTitle
+    - name: Run desktop_generic protocol that contains SuspiciousTag with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSuspiciousTag
     
-    - name: Run desktop_generic protocol using specific filtering and detect a SuspiciousTitle with TESTAR
-      run: ./gradlew runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle
+    - name: Run desktop_generic protocol using specific filtering and detect a SuspiciousTag with TESTAR
+      run: ./gradlew runTestDesktopGenericCommandLineSettingsFilterSuspiciousTag
     
-    - name: Run desktop_generic protocol but connect using SUT_PROCESS_NAME and detect SuspiciousTitle
-      run: ./gradlew runTestDesktopGenericProcessNameSuspiciousTitle
+    - name: Run desktop_generic protocol but connect using SUT_PROCESS_NAME and detect SuspiciousTag
+      run: ./gradlew runTestDesktopGenericProcessNameSuspiciousTag
     
-    - name: Run desktop_generic protocol but connect using SUT_WINDOW_TITLE and detect SuspiciousTitle
-      run: ./gradlew runTestDesktopGenericTitleNameSuspiciousTitle
+    - name: Run desktop_generic protocol but connect using SUT_WINDOW_TITLE and detect SuspiciousTag
+      run: ./gradlew runTestDesktopGenericTitleNameSuspiciousTag
     
     - name: Run desktop_generic with OrientDB to infer a TESTAR State Model
       run: ./gradlew runTestDesktopGenericStateModel
@@ -261,8 +261,8 @@ jobs:
     - name: Run desktop_generic doing a customization in the AbstractIDCustom identifer
       run: ./gradlew runTestDesktopGenericStateModelCustomAbstraction
     
-    - name: Run webdriver protocol and detect SuspiciousTitle
-      run: ./gradlew runTestWebdriverSuspiciousTitle
+    - name: Run webdriver protocol and detect SuspiciousTag
+      run: ./gradlew runTestWebdriverSuspiciousTag
     
     - name: Run webdriver to login in parabank and detect browser console error
       run: ./gradlew runTestWebdriverParabankLoginAndConsoleError

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ Some of the most interesting parameters that can help to integrate TESTAR as an 
 
 		Sequences & SequenceLength -> The number of iterations and actions that TESTAR will execute
 
-		SuspiciousTitles -> The errors that TESTAR will search in the execution
+		SuspiciousTags -> The errors that TESTAR will search in the execution
 
 Example: 
 
-``testar sse=desktop_generic ShowVisualSettingsDialogOnStartup=false Sequences=5 SequenceLength=100 Mode=Generate SUTConnectorValue=" ""C:\\Program Files\\VideoLAN\\VLC\\vlc.exe"" " SuspiciousTitles=".*[eE]rror.*|.*[eE]xcep[ct]ion.*"``
+``testar sse=desktop_generic ShowVisualSettingsDialogOnStartup=false Sequences=5 SequenceLength=100 Mode=Generate SUTConnectorValue=" ""C:\\Program Files\\VideoLAN\\VLC\\vlc.exe"" " SuspiciousTags=".*[eE]rror.*|.*[eE]xcep[ct]ion.*"``
 
 ## State Model / Graph database support
 TESTAR uses orientdb graph database http://orientdb.com , to create TESTAR GUI State Models.  

--- a/core/src/org/testar/monkey/alayer/Tag.java
+++ b/core/src/org/testar/monkey/alayer/Tag.java
@@ -1,36 +1,33 @@
 /***************************************************************************************************
-*
-* Copyright (c) 2013, 2014, 2015, 2016, 2017 Universitat Politecnica de Valencia - www.upv.es
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-* notice, this list of conditions and the following disclaimer in the
-* documentation and/or other materials provided with the distribution.
-* 3. Neither the name of the copyright holder nor the names of its
-* contributors may be used to endorse or promote products derived from
-* this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*******************************************************************************************************/
+ *
+ * Copyright (c) 2013 - 2023 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2018 - 2023 Open Universiteit - www.ou.nl
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************************************/
 
-
-/**
- *  @author Sebastian Bauersfeld
- */
 package org.testar.monkey.alayer;
 
 import java.io.IOException;
@@ -65,10 +62,17 @@ public final class Tag<T> implements Serializable{
 		return ret;
 	}
 
+	public static <T> Tag<T> from(String name, Class<T> valueType, String description){
+		Tag<T> ret = from(name, valueType);
+		ret.description = description;
+		return ret;
+	}
+
 	private static final long serialVersionUID = -1215427100999751182L;
 	private final Class<T> clazz;
 	private final String name;
 	private int hashcode;
+	private String description = "";
 
 	private Tag(String name, Class<T> clazz){
 		this.clazz = clazz;
@@ -80,15 +84,14 @@ public final class Tag<T> implements Serializable{
 	 * @return the name of the tag
 	 */
 	public String name() { return name; }
-	
-	
+
 	/**
 	 * The type of the values associated with this tag (e.g. <code>String</code>)
 	 * @return value type
 	 */
 	public Class<T> type() { return clazz; }
 	public String toString(){ return name; }
-	
+
 	public int hashCode(){
 		int ret = hashcode;
 		if(ret == 0){
@@ -96,6 +99,10 @@ public final class Tag<T> implements Serializable{
 			hashcode = ret;
 		}
 		return hashcode;
+	}
+
+	public String getDescription() {
+		return description;
 	}
 
 	public boolean equals(Object other){
@@ -107,17 +114,16 @@ public final class Tag<T> implements Serializable{
 		}
 		return false;
 	}
-	
+
 	private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException{
 		ois.defaultReadObject();
 	}
-	
+
 	private Object readResolve() throws ObjectStreamException{
 		Tag<?> existing = existingTags.putIfAbsent(this, this);		
 		return existing == null ? this : existing;
 	}
-	
-	// by urueda
+
 	public boolean isOneOf(Tag<?>... oneOf){
 		Assert.notNull(this, oneOf);
 		for(Tag<?> o : oneOf){
@@ -126,5 +132,5 @@ public final class Tag<T> implements Serializable{
 		}
 		return false;
 	}	
-	
+
 }

--- a/core/src/org/testar/monkey/alayer/Verdict.java
+++ b/core/src/org/testar/monkey/alayer/Verdict.java
@@ -51,7 +51,7 @@ public final class Verdict implements Serializable {
 	public static final double SEVERITY_SUSPICIOUS_TAG = 0.00000009; // suspicious tag
 	// FAIL
 	public static final double SEVERITY_NOT_RESPONDING =   0.99999990; // unresponsive
-	public static final double SEVERITY_NOT_RUNNING =	   0.99999999; // crash? unexpected close?
+	public static final double SEVERITY_UNEXPECTEDCLOSE =	   0.99999999; // crash? unexpected close?
 	public static final double SEVERITY_MAX = 1.0;
 
 	public static final double SEVERITY_OK = 			   SEVERITY_MIN;
@@ -101,8 +101,8 @@ public final class Verdict implements Serializable {
 			return "SUSPICIOUS_TAG";
 		if(severity == Verdict.SEVERITY_NOT_RESPONDING)
 			return "NOT_RESPONDING";
-		if(severity == Verdict.SEVERITY_NOT_RUNNING)
-			return "NOT_RUNNING";
+		if(severity == Verdict.SEVERITY_UNEXPECTEDCLOSE)
+			return "UNEXPECTEDCLOSE";
 		if(severity == Verdict.SEVERITY_UNREPLAYABLE)
 			return "NOT_REPLAYABLE";
 

--- a/core/src/org/testar/monkey/alayer/Verdict.java
+++ b/core/src/org/testar/monkey/alayer/Verdict.java
@@ -48,7 +48,7 @@ public final class Verdict implements Serializable {
 	// PASS
 	public static final double SEVERITY_MIN = 0.0;
 	public static final double SEVERITY_WARNING = 		   0.00000001; // must be less than FAULT THRESHOLD @test.settings
-	public static final double SEVERITY_SUSPICIOUS_TITLE = 0.00000009; // suspicious title
+	public static final double SEVERITY_SUSPICIOUS_TAG = 0.00000009; // suspicious tag
 	// FAIL
 	public static final double SEVERITY_NOT_RESPONDING =   0.99999990; // unresponsive
 	public static final double SEVERITY_NOT_RUNNING =	   0.99999999; // crash? unexpected close?
@@ -97,8 +97,8 @@ public final class Verdict implements Serializable {
 			return "OK";
 		if(severity == Verdict.SEVERITY_WARNING)
 			return "WARNING";
-		if(severity == Verdict.SEVERITY_SUSPICIOUS_TITLE)
-			return "SUSPICIOUS_TITLE";
+		if(severity == Verdict.SEVERITY_SUSPICIOUS_TAG)
+			return "SUSPICIOUS_TAG";
 		if(severity == Verdict.SEVERITY_NOT_RESPONDING)
 			return "NOT_RESPONDING";
 		if(severity == Verdict.SEVERITY_NOT_RUNNING)

--- a/testar/resources/settings/01_desktop_calculator/Protocol_01_desktop_calculator.java
+++ b/testar/resources/settings/01_desktop_calculator/Protocol_01_desktop_calculator.java
@@ -1,8 +1,7 @@
-
 /***************************************************************************************************
  *
- * Copyright (c) 2020 Universitat Politecnica de Valencia - www.upv.es
- * Copyright (c) 2020 Open Universiteit - www.ou.nl
+ * Copyright (c) 2020 - 2023 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2020 - 2023 Open Universiteit - www.ou.nl
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -49,7 +48,7 @@ import java.util.Set;
  *
  * It uses random action selection algorithm.
  */
-public class Protocol_desktop_generic_pure_random extends DesktopProtocol {
+public class Protocol_01_desktop_calculator extends DesktopProtocol {
 
 	/**
 	 * Called once during the life time of TESTAR
@@ -92,9 +91,9 @@ public class Protocol_desktop_generic_pure_random extends DesktopProtocol {
 	 * or bringing the system into a specific start state which is identical on each start (e.g. one has to delete or restore
 	 * the SUT's configuration files etc.)
 	 */
-	 @Override
+	@Override
 	protected void beginSequence(SUT system, State state){
-	 	super.beginSequence(system, state);
+		super.beginSequence(system, state);
 	}
 
 	/**
@@ -151,11 +150,12 @@ public class Protocol_desktop_generic_pure_random extends DesktopProtocol {
 		Set<Action> actions = super.deriveActions(system,state);
 
 		// Derive left-click actions, click and type actions, and scroll actions from
-		// all widgets of the GUI:
-		DerivedActions derived = deriveClickTypeScrollActionsFromAllWidgets(actions, state);
 
-		// The other option would be deriving actions only from the top level widgets:
-		// DerivedActions derived = deriveClickTypeScrollActionsFromTopLevelWidgets(actions, state);
+		// all widgets of the GUI:
+		//DerivedActions derived = deriveClickTypeScrollActionsFromAllWidgets(actions, state);
+
+		// the top level widgets of the GUI such as menu items:
+		DerivedActions derived = deriveClickTypeScrollActionsFromTopLevelWidgets(actions, state);
 
 		Set<Action> filteredActions = derived.getFilteredActions();
 		actions = derived.getAvailableActions();
@@ -178,7 +178,7 @@ public class Protocol_desktop_generic_pure_random extends DesktopProtocol {
 	 */
 	@Override
 	protected Action selectAction(State state, Set<Action> actions){
-		return(super.selectAction(state, actions));
+		return super.selectAction(state, actions);
 	}
 
 	/**

--- a/testar/resources/settings/01_desktop_calculator/test.settings
+++ b/testar/resources/settings/01_desktop_calculator/test.settings
@@ -23,7 +23,7 @@ Mode = Spy
 # The SUT must be manually started and closed.
 #################################################################
 SUTConnector = COMMAND_LINE
-SUTConnectorValue = c:\\windows\\system32\\notepad.exe
+SUTConnectorValue = java -jar suts/Calculator.jar
 
 #################################################################
 # Sequences
@@ -31,8 +31,8 @@ SUTConnectorValue = c:\\windows\\system32\\notepad.exe
 # Number of sequences and the length of these sequences
 #################################################################
 
-Sequences = 2
-SequenceLength = 20
+Sequences = 8
+SequenceLength = 10
 
 #################################################################
 # Oracles based on suspicious titles
@@ -96,7 +96,7 @@ SUTProcesses =
 # Indicate the location of the protocol class for your specific SUT.
 #################################################################
 
-ProtocolClass = 01_desktop_generic_pure_random/Protocol_desktop_generic_pure_random
+ProtocolClass = 01_desktop_calculator/Protocol_01_desktop_calculator
 
 #################################################################
 # State identifier attributes
@@ -131,13 +131,13 @@ FaultThreshold = 0.000000001
 DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
-ActionDuration = 0.1
+ActionDuration = 0.3
 ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
 ShowSettingsAfterTest = true
-TimeToWaitAfterAction = 0.1
+TimeToWaitAfterAction = 0.3
 StartupTime = 10.0
 DrawWidgetInfo = false
 TimeToFreeze = 30.0

--- a/testar/resources/settings/01_desktop_calculator/test.settings
+++ b/testar/resources/settings/01_desktop_calculator/test.settings
@@ -91,12 +91,28 @@ TagsToFilter = Title
 ProcessesToKillDuringTest =
 
 #################################################################
-# Protocolclass
+# SUT Protocol
 #
-# Indicate the location of the protocol class for your specific SUT.
+# ProtocolClass: Indicate the location of the protocol class for your specific SUT
+# AlwaysCompile: Compile the protocol before launching the selected TESTAR mode
 #################################################################
 
 ProtocolClass = 01_desktop_calculator/Protocol_01_desktop_calculator
+AlwaysCompile = true
+
+#################################################################
+# Time configurations
+#
+# ActionDuration: Sets the speed, in seconds, at which a GUI action is performed
+# TimeToWaitAfterAction: Sets the delay, in seconds, between UI actions during a test
+# StartupTime: Sets how many seconds to wait for the SUT to be ready for testing
+# MaxTime: Sets a time, in seconds, after which the test run is finished (e.g. stop after an hour)
+#################################################################
+
+ActionDuration = 0.0
+TimeToWaitAfterAction = 0.3
+StartupTime = 10.0
+MaxTime = 3.1536E7
 
 #################################################################
 # State identifier attributes
@@ -116,6 +132,24 @@ ProtocolSpecificSetting_4 =
 ProtocolSpecificSetting_5 = 
 
 #################################################################
+# Sets whether to display TESTAR dialog. If false is used, then TESTAR will run in the mode of the Mode property
+#################################################################
+
+ShowVisualSettingsDialogOnStartup = true
+
+#################################################################
+# Sets whether to keep the SUTs GUI active in the screen (e.g. when its minimised or when a process is started and its UI is in front, etc.)
+#################################################################
+
+ForceForeground = true
+
+#################################################################
+# Sets whether to display overlay information, inside the SPY mode, for all the UI actions derived from the test set up
+#################################################################
+
+VisualizeActions = false
+
+#################################################################
 # Other more advanced settings
 #################################################################
 
@@ -123,21 +157,14 @@ OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
-ForceForeground = true
 LogLevel = 1
 FaultThreshold = 0.000000001
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
-ActionDuration = 0.0
-ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
-MaxTime = 3.1536E7
-TimeToWaitAfterAction = 0.3
-StartupTime = 10.0
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
-VisualizeActions = false
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/settings/01_desktop_calculator/test.settings
+++ b/testar/resources/settings/01_desktop_calculator/test.settings
@@ -35,12 +35,12 @@ Sequences = 8
 SequenceLength = 10
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = 
+SuspiciousTags = 
 TagsForSuspiciousOracle = Title
 
 #################################################################
@@ -88,7 +88,7 @@ TagsToFilter = Title
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -119,16 +119,13 @@ ProtocolSpecificSetting_5 =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.0
@@ -136,15 +133,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.3
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/settings/01_desktop_calculator/test.settings
+++ b/testar/resources/settings/01_desktop_calculator/test.settings
@@ -104,7 +104,7 @@ ProtocolClass = 01_desktop_calculator/Protocol_01_desktop_calculator
 # Specify the widget attributes that you wish to use in constructing
 # the widget and state hash strings. Use a comma separated list.
 #################################################################
-AbstractStateAttributes = WidgetControlType
+AbstractStateAttributes = WidgetControlType,WidgetTitle
 
 #################################################################
 # Settings (string) that can be used for user specified protocols
@@ -131,7 +131,7 @@ FaultThreshold = 0.000000001
 DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
-ActionDuration = 0.3
+ActionDuration = 0.0
 ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =

--- a/testar/resources/settings/02_webdriver_parabank/Protocol_02_webdriver_parabank.java
+++ b/testar/resources/settings/02_webdriver_parabank/Protocol_02_webdriver_parabank.java
@@ -49,7 +49,7 @@ import static org.testar.monkey.alayer.webdriver.Constants.scrollArrowSize;
 import static org.testar.monkey.alayer.webdriver.Constants.scrollThick;
 
 
-public class Protocol_webdriver_parabank extends WebdriverProtocol {
+public class Protocol_02_webdriver_parabank extends WebdriverProtocol {
 
   /**
    * Called once during the life time of TESTAR

--- a/testar/resources/settings/02_webdriver_parabank/Protocol_webdriver_parabank.java
+++ b/testar/resources/settings/02_webdriver_parabank/Protocol_webdriver_parabank.java
@@ -167,7 +167,7 @@ public class Protocol_webdriver_parabank extends WebdriverProtocol {
 
     for(Widget w : state) {
       if(w.get(WdTags.WebTextContent,"").contains("internal error")) {
-        return new Verdict(Verdict.SEVERITY_SUSPICIOUS_TITLE,
+        return new Verdict(Verdict.SEVERITY_SUSPICIOUS_TAG,
                 "Discovered suspicious widget 'Web Text Content' : '" + w.get(WdTags.WebTextContent,"") + "'.");
       }
     }

--- a/testar/resources/settings/02_webdriver_parabank/test.settings
+++ b/testar/resources/settings/02_webdriver_parabank/test.settings
@@ -27,7 +27,7 @@ Mode = Spy
 # Example format for the dimensions and position : 1920x1000+1680+0
 #################################################################
 SUTConnector = WEB_DRIVER
-SUTConnectorValue = "C:\\Windows\\chromedriver.exe" "1920x900+0+0" "https://para.testar.org/"
+SUTConnectorValue = "C:\\Windows\\chromedriver.exe" "https://para.testar.org/"
 
 #################################################################
 # Sequences
@@ -35,8 +35,8 @@ SUTConnectorValue = "C:\\Windows\\chromedriver.exe" "1920x900+0+0" "https://para
 # Number of sequences and the length of these sequences
 #################################################################
 
-Sequences = 1
-SequenceLength = 100
+Sequences = 5
+SequenceLength = 20
 
 #################################################################
 # Oracles based on suspicious tag values
@@ -95,29 +95,62 @@ TagsToFilter = Title;WebName;WebTagName
 ProcessesToKillDuringTest =
 
 #################################################################
-# Protocolclass
+# SUT Protocol
 #
-# Indicate the location of the protocol class for your specific SUT.
+# ProtocolClass: Indicate the location of the protocol class for your specific SUT
+# AlwaysCompile: Compile the protocol before launching the selected TESTAR mode
 #################################################################
 
-ProtocolClass = 02_webdriver_parabank/Protocol_webdriver_parabank
+ProtocolClass = 02_webdriver_parabank/Protocol_02_webdriver_parabank
+AlwaysCompile = true
+
+#################################################################
+# Time configurations
+#
+# ActionDuration: Sets the speed, in seconds, at which a GUI action is performed
+# TimeToWaitAfterAction: Sets the delay, in seconds, between UI actions during a test
+# StartupTime: Sets how many seconds to wait for the SUT to be ready for testing
+# MaxTime: Sets a time, in seconds, after which the test run is finished (e.g. stop after an hour)
+#################################################################
+
+ActionDuration = 0.1
+TimeToWaitAfterAction = 0.1
+StartupTime = 2.0
+MaxTime = 3.1536E7
 
 #################################################################
 # State model inference settings
+#
+# StateModelEnabled: Enable or disable the State Model feature
+# DataStore: The graph database we use to store the State Model: OrientDB
+# DataStoreType: The mode we use to connect to the database: remote or plocal
+# DataStoreServer: IP address to connect if we desired to use remote mode
+# DataStoreDirectory: Path of the directory on which local OrientDB exists, if we use plocal mode
+# DataStoreDB: The name of the desired database on which we want to store the State Model.
+# DataStoreUser: User credential to authenticate TESTAR in OrientDB
+# DataStorePassword: Password credential to authenticate TESTAR in OrientDB
+# DataStoreMode: Indicate how TESTAR should store the model objects in the database: instant, delayed, hybrid, none
+# ApplicationName: Name to identify the SUT. Especially important to identify a State Model
+# ApplicationVersion: Version to identify the SUT. Especially important to identify a State Model
+# ActionSelectionAlgorithm: State Model Action Selection mechanism to explore the SUT: random or unvisited
+# StateModelStoreWidgets: Save all widget tree information in the State Model every time TESTAR discovers a new Concrete State
+# ResetDataStore: WARNING: Delete all existing State Models from the selected database before creating a new one
 #################################################################
+
 StateModelEnabled = false
-DataStore =
+DataStore = 
 DataStoreType = remote
-DataStoreServer =
-DataStoreDirectory =
-DataStoreDB =
-DataStoreUser =
-DataStorePassword =
+DataStoreServer = 
+DataStoreDirectory = 
+DataStoreDB = 
+DataStoreUser = 
+DataStorePassword = 
 DataStoreMode = none
 ApplicationName = Parabank
-ApplicationVersion =
+ApplicationVersion = 
 ActionSelectionAlgorithm = random
 StateModelStoreWidgets = true
+ResetDataStore = false
 
 #################################################################
 # State identifier attributes
@@ -129,7 +162,16 @@ AbstractStateAttributes = WebWidgetId
 
 #################################################################
 # WebDriver features
+#
+# ClickableClasses: Indicate which web CSS classes need to be considered clickable
+# TypeableClasses: Indicate which web CSS classes need to be considered typeable
+# DeniedExtensions: Indicate which web URL extensions need to be ignored when testing
+# DomainsAllowed: Indicate which web URL domains need to be ignored when testing
+# FollowLinks: Indicate if allowing to follow links opened in new tabs
+# BrowserFullScreen: Indicate if perform the web testing with the browser in full screen
+# SwitchNewTabs: Indicate if switch to a new web tab if opened
 #################################################################
+
 ClickableClasses = 
 TypeableClasses = 
 DeniedExtensions = pdf;jpg;png;pfx;xml
@@ -140,7 +182,13 @@ SwitchNewTabs = true
 
 #################################################################
 # WebDriver Browser Console Oracles
+#
+# WebConsoleErrorOracle: Enable or Disable applying ORACLES to the browser error console
+# WebConsoleErrorPattern: Regular expressions ORACLE to find suspicious messages in the browser error console
+# WebConsoleWarningOracle: Enable or Disable applying ORACLES to the browser warning console
+# WebConsoleWarningPattern: Regular expressions ORACLE to find suspicious messages in the browser warning console
 #################################################################
+
 WebConsoleErrorOracle = false
 WebConsoleErrorPattern = .*.*
 WebConsoleWarningOracle = false
@@ -171,6 +219,24 @@ ProtocolSpecificSetting_4 =
 ProtocolSpecificSetting_5 = 
 
 #################################################################
+# Sets whether to display TESTAR dialog. If false is used, then TESTAR will run in the mode of the Mode property
+#################################################################
+
+ShowVisualSettingsDialogOnStartup = true
+
+#################################################################
+# Sets whether to keep the SUTs GUI active in the screen (e.g. when its minimised or when a process is started and its UI is in front, etc.)
+#################################################################
+
+ForceForeground = true
+
+#################################################################
+# Sets whether to display overlay information, inside the SPY mode, for all the UI actions derived from the test set up
+#################################################################
+
+VisualizeActions = false
+
+#################################################################
 # Other more advanced settings
 #################################################################
 
@@ -178,21 +244,14 @@ OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
-ForceForeground = true
 LogLevel = 1
 FaultThreshold = 1.0E-9
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
-ActionDuration = 0.1
-ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
-MaxTime = 3.1536E7
-TimeToWaitAfterAction = 0.1
-StartupTime = 2.0
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
-VisualizeActions = false
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/settings/02_webdriver_parabank/test.settings
+++ b/testar/resources/settings/02_webdriver_parabank/test.settings
@@ -39,12 +39,12 @@ Sequences = 1
 SequenceLength = 100
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
@@ -92,7 +92,7 @@ TagsToFilter = Title;WebName;WebTagName
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -173,16 +173,13 @@ ProtocolSpecificSetting_5 =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -190,15 +187,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/settings/android_generic/test.settings
+++ b/testar/resources/settings/android_generic/test.settings
@@ -35,12 +35,12 @@ Sequences = 5
 SequenceLength = 10
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title
 
 #################################################################
@@ -88,7 +88,7 @@ TagsToFilter = Title
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -110,16 +110,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -127,16 +124,12 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 2
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95
 UseSystemActions = false

--- a/testar/resources/settings/desktop_generic/test.settings
+++ b/testar/resources/settings/desktop_generic/test.settings
@@ -35,12 +35,12 @@ Sequences = 8
 SequenceLength = 10
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title
 
 #################################################################
@@ -88,7 +88,7 @@ TagsToFilter = Title
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -131,16 +131,13 @@ ProtocolSpecificSetting_5 =
 # Other more advanced settings
 #################################################################
 CreateWidgetInfoJsonFile = true
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -148,15 +145,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/settings/desktop_generic_action_selector/test.settings
+++ b/testar/resources/settings/desktop_generic_action_selector/test.settings
@@ -35,12 +35,12 @@ Sequences = 2
 SequenceLength = 50
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title
 
 #################################################################
@@ -88,7 +88,7 @@ TagsToFilter = Title
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -122,16 +122,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 CreateWidgetInfoJsonFile = false
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -139,15 +136,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/settings/desktop_swingset2/test.settings
+++ b/testar/resources/settings/desktop_swingset2/test.settings
@@ -46,12 +46,12 @@ Sequences = 1
 SequenceLength = 100
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title
 
 #################################################################
@@ -99,7 +99,7 @@ TagsToFilter = Title
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -121,16 +121,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -138,15 +135,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/settings/desktop_widget_recognition/test.settings
+++ b/testar/resources/settings/desktop_widget_recognition/test.settings
@@ -35,12 +35,12 @@ Sequences = 8
 SequenceLength = 10
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title
 
 #################################################################
@@ -88,7 +88,7 @@ TagsToFilter = Title
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -110,16 +110,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 CreateWidgetInfoJsonFile = true
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -127,15 +124,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/settings/webdriver_generic/test.settings
+++ b/testar/resources/settings/webdriver_generic/test.settings
@@ -39,12 +39,12 @@ Sequences = 1
 SequenceLength = 100
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
@@ -92,7 +92,7 @@ TagsToFilter = Title;WebName;WebTagName
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -168,16 +168,13 @@ ProtocolSpecificSetting_5 =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -185,16 +182,12 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95
 RefreshSpyCanvas = 1.0

--- a/testar/resources/settings/webdriver_generic_action_selector/test.settings
+++ b/testar/resources/settings/webdriver_generic_action_selector/test.settings
@@ -39,12 +39,12 @@ Sequences = 1
 SequenceLength = 100
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
@@ -92,7 +92,7 @@ TagsToFilter = Title;WebName;WebTagName
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -147,16 +147,13 @@ OverrideWebDriverDisplayScale =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -164,16 +161,12 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95
 RefreshSpyCanvas = 1.0

--- a/testar/resources/settings/webdriver_gwt/test.settings
+++ b/testar/resources/settings/webdriver_gwt/test.settings
@@ -39,12 +39,12 @@ Sequences = 1
 SequenceLength = 100
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
@@ -92,7 +92,7 @@ TagsToFilter = Title;WebName;WebTagName
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -147,16 +147,13 @@ OverrideWebDriverDisplayScale =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -164,16 +161,12 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95
 RefreshSpyCanvas = 1.0

--- a/testar/resources/settings/webdriver_security_analysis/test.settings
+++ b/testar/resources/settings/webdriver_security_analysis/test.settings
@@ -39,12 +39,12 @@ Sequences = 1
 SequenceLength = 10
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title;WebName;WebTagName
 
 #################################################################
@@ -92,7 +92,7 @@ TagsToFilter = Title;WebName;WebTagName
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -156,16 +156,13 @@ ProtocolSpecificSetting_5 =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -173,16 +170,12 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95
 RefreshSpyCanvas = 1.0

--- a/testar/resources/settings/winapi_web_generic/test.settings
+++ b/testar/resources/settings/winapi_web_generic/test.settings
@@ -35,12 +35,12 @@ Sequences = 1
 SequenceLength = 100
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title
 
 #################################################################
@@ -88,7 +88,7 @@ TagsToFilter = Title
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -110,16 +110,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -127,15 +124,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/settings/winapi_web_one_drive/test.settings
+++ b/testar/resources/settings/winapi_web_one_drive/test.settings
@@ -35,12 +35,12 @@ Sequences = 1
 SequenceLength = 100
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression and Tags to apply them
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 TagsForSuspiciousOracle = Title
 
 #################################################################
@@ -88,7 +88,7 @@ TagsToFilter = Title
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -110,16 +110,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -127,15 +124,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic/test.settings
@@ -35,12 +35,12 @@ Sequences = 8
 SequenceLength = 10
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners
@@ -85,7 +85,7 @@ ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -107,16 +107,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 CreateWidgetInfoJsonFile = true
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -124,15 +121,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic_custom_abstraction/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic_custom_abstraction/test.settings
@@ -35,12 +35,12 @@ Sequences = 1
 SequenceLength = 1
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners
@@ -85,7 +85,7 @@ ClickFilter = .*[sS]ystem.*|.*[cC]lose.*|.*[mM]inimize.*|.*[mM]aximize.*|Text Ed
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -124,16 +124,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.5
@@ -141,15 +138,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 2.0
 StartupTime = 20.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic_multitags/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic_multitags/test.settings
@@ -35,12 +35,12 @@ Sequences = 1
 SequenceLength = 1
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners
@@ -85,7 +85,7 @@ ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -107,16 +107,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 1
@@ -124,15 +121,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 1
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic_statemodel/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_desktop_generic_statemodel/test.settings
@@ -35,12 +35,12 @@ Sequences = 1
 SequenceLength = 2
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners
@@ -85,7 +85,7 @@ ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -124,16 +124,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.5
@@ -141,15 +138,11 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.5
 StartupTime = 20.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/workflow/settings/test_gradle_workflow_run_gui/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_run_gui/test.settings
@@ -35,12 +35,12 @@ Sequences = 1
 SequenceLength = 1
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners
@@ -85,7 +85,7 @@ ClickFilter = .*[sS]istema.*|.*[sS]ystem.*|.*[cC]errar.*|.*[cC]lose.*|.*[sS]alir
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -107,16 +107,13 @@ AbstractStateAttributes = WidgetControlType
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 0.000000001
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -124,15 +121,11 @@ ShowVisualSettingsDialogOnStartup = false
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 10.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95

--- a/testar/resources/workflow/settings/test_gradle_workflow_webdriver_form_filling/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_webdriver_form_filling/test.settings
@@ -39,12 +39,12 @@ Sequences = 1
 SequenceLength = 1
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners
@@ -89,7 +89,7 @@ ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]ri
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -153,16 +153,13 @@ ProtocolSpecificSetting_5 =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -170,16 +167,12 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95
 RefreshSpyCanvas = 1.0

--- a/testar/resources/workflow/settings/test_gradle_workflow_webdriver_generic/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_webdriver_generic/test.settings
@@ -39,12 +39,12 @@ Sequences = 1
 SequenceLength = 2
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners
@@ -89,7 +89,7 @@ ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]ri
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -144,16 +144,13 @@ OverrideWebDriverDisplayScale =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -161,16 +158,12 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95
 RefreshSpyCanvas = 1.0

--- a/testar/resources/workflow/settings/test_gradle_workflow_webdriver_parabank/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_webdriver_parabank/test.settings
@@ -39,12 +39,12 @@ Sequences = 1
 SequenceLength = 1
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression
 #################################################################
 
-SuspiciousTitles = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
+SuspiciousTags = .*[eE]rror.*|.*[eE]xcepti[o?]n.*
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners
@@ -89,7 +89,7 @@ ClickFilter = .*[sS]ave.*|.*[gG]uardar.*|.*[fF]ormat.*|.*[fF]ormatear.*|.*[pP]ri
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -153,16 +153,13 @@ ProtocolSpecificSetting_5 =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.1
@@ -170,16 +167,12 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.1
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95
 RefreshSpyCanvas = 1.0

--- a/testar/resources/workflow/settings/test_gradle_workflow_webdriver_replay/test.settings
+++ b/testar/resources/workflow/settings/test_gradle_workflow_webdriver_replay/test.settings
@@ -39,12 +39,12 @@ Sequences = 1
 SequenceLength = 1
 
 #################################################################
-# Oracles based on suspicious titles
+# Oracles based on suspicious tag values
 #
 # Regular expression
 #################################################################
 
-SuspiciousTitles = 
+SuspiciousTags = 
 
 #################################################################
 # Oracles based on Suspicious Outputs detected by Process Listeners
@@ -89,7 +89,7 @@ ClickFilter =
 # but that you do not want to test.
 #################################################################
 
-SUTProcesses =
+ProcessesToKillDuringTest =
 
 #################################################################
 # Protocolclass
@@ -144,16 +144,13 @@ OverrideWebDriverDisplayScale =
 # Other more advanced settings
 #################################################################
 
-ProcessesToKillDuringTest =
 OutputDir = ./output
 PathToReplaySequence = ./output/temp
 TempDir = ./output/temp
 UseRecordedActionDurationAndWaitTimeDuringReplay = false
 ForceForeground = true
 LogLevel = 1
-ExecuteActions = true
 FaultThreshold = 1.0E-9
-DrawWidgetUnderCursor = true
 MyClassPath = ./settings
 OnlySaveFaultySequences = false
 ActionDuration = 0.5
@@ -161,16 +158,12 @@ ShowVisualSettingsDialogOnStartup = true
 ReplayRetryTime = 30.0
 Delete =
 MaxTime = 3.1536E7
-ShowSettingsAfterTest = true
 TimeToWaitAfterAction = 0.5
 StartupTime = 2.0
-DrawWidgetInfo = false
 TimeToFreeze = 30.0
 StopGenerationOnFault = true
 CopyFromTo =
 VisualizeActions = false
-VisualizeSelectedAction = true
-TestGenerator = random
 MaxReward = 9999999
 Discount = .95
 RefreshSpyCanvas = 1.0

--- a/testar/src/org/testar/FileHandling.java
+++ b/testar/src/org/testar/FileHandling.java
@@ -101,7 +101,7 @@ public class FileHandling {
             targetFolder = "sequences_suspicious_tag";
         else if (sev == Verdict.SEVERITY_NOT_RESPONDING)
             targetFolder = "sequences_unresponsive";
-        else if (sev == Verdict.SEVERITY_NOT_RUNNING)
+        else if (sev == Verdict.SEVERITY_UNEXPECTEDCLOSE)
             targetFolder = "sequences_unexpectedclose";
         else if (sev == Verdict.SEVERITY_FAIL)
             targetFolder = "sequences_fail";

--- a/testar/src/org/testar/FileHandling.java
+++ b/testar/src/org/testar/FileHandling.java
@@ -97,8 +97,8 @@ public class FileHandling {
             targetFolder = "sequences_ok";
         else if (sev == Verdict.SEVERITY_WARNING)
             targetFolder = "sequences_warning";
-        else if (sev == Verdict.SEVERITY_SUSPICIOUS_TITLE)
-            targetFolder = "sequences_suspicioustitle";
+        else if (sev == Verdict.SEVERITY_SUSPICIOUS_TAG)
+            targetFolder = "sequences_suspicious_tag";
         else if (sev == Verdict.SEVERITY_NOT_RESPONDING)
             targetFolder = "sequences_unresponsive";
         else if (sev == Verdict.SEVERITY_NOT_RUNNING)

--- a/testar/src/org/testar/ProcessListener.java
+++ b/testar/src/org/testar/ProcessListener.java
@@ -133,8 +133,8 @@ public class ProcessListener{
 							if(DefaultProtocol.lastExecutedAction!=null)
 								actionId=DefaultProtocol.lastExecutedAction.get(Tags.ConcreteID);
 
-							Verdict verdict = new Verdict(Verdict.SEVERITY_SUSPICIOUS_TITLE,
-									"Process Listener suspicious title: '" + ch + ", on Action:	'"+actionId+".");
+							Verdict verdict = new Verdict(Verdict.SEVERITY_SUSPICIOUS_TAG,
+									"Process Listener suspicious tag: '" + ch + ", on Action:	'"+actionId+".");
 
 							//Set that we found an error
 							DefaultProtocol.processVerdict = verdict;
@@ -205,8 +205,8 @@ public class ProcessListener{
 							if(DefaultProtocol.lastExecutedAction!=null)
 								actionId=DefaultProtocol.lastExecutedAction.get(Tags.ConcreteID);
 
-							Verdict verdict = new Verdict(Verdict.SEVERITY_SUSPICIOUS_TITLE,
-									"Process Listener suspicious title: '" + ch + ", on Action:	'"+actionId+".");
+							Verdict verdict = new Verdict(Verdict.SEVERITY_SUSPICIOUS_TAG,
+									"Process Listener suspicious tag: '" + ch + ", on Action:	'"+actionId+".");
 
 							//Set that we found an error
 							DefaultProtocol.processVerdict = verdict;

--- a/testar/src/org/testar/SutVisualization.java
+++ b/testar/src/org/testar/SutVisualization.java
@@ -79,37 +79,56 @@ public class SutVisualization {
 
         if(cursorWidget != null){
             Widget rootW = cursorWidget;
-            while (rootW.parent() != null && rootW.parent() != rootW)
+            while (rootW.parent() != null && rootW.parent() != rootW) {
                 rootW = rootW.parent();
+            }
             Shape cwShape = cursorWidget.get(Tags.Shape, null);
 
             if(cwShape != null){
                 cwShape.paint(canvas, Pen.PEN_MARK_ALPHA);
                 cwShape.paint(canvas, Pen.PEN_MARK_BORDER);
                 if (!showExtendedWidgetInfo){
-                    String rootText = "State: " + rootW.get(Tags.ConcreteID),
-                            widConcreteText = CodingManager.CONCRETE_ID + ": " + cursorWidget.get(Tags.ConcreteID),
-                            roleText = "Role: " + cursorWidget.get(Role, Roles.Widget).toString(),
-                            idxText = "Path: " + cursorWidget.get(Tags.Path);
+                	// Widget properties we are going to show in Spy mode when the information is not extended
+                	String rootText = "StateID: " + rootW.get(Tags.AbstractIDCustom, "");
+                	String widgetText = "WidgetID: " + cursorWidget.get(Tags.AbstractIDCustom, "");
+                	String titleText = "Title: " + cursorWidget.get(Tags.Title, "");
+                	String roleText = "Role: " + cursorWidget.get(Role, Roles.Widget).toString();
+                	String enabledText = "Enabled: " + cursorWidget.get(Tags.Enabled, false);
+                	String shapeText = "Shape: " + cursorWidget.get(Tags.Shape);
+                	String pathText = "Path: " + cursorWidget.get(Tags.Path, "");
 
-                    double miniwidgetInfoW = Math.max(Math.max(Math.max(rootText.length(), widConcreteText.length()), roleText.length()),idxText.length()) * 8; if (miniwidgetInfoW < 256) miniwidgetInfoW = 256;
-                    double miniwidgetInfoH = 80; // 20 * 4
-                    Shape minicwShape = Rect.from(cwShape.x() + cwShape.width()/2 + 32,
-                            cwShape.y() + cwShape.height()/2 + 32,
-                            miniwidgetInfoW, miniwidgetInfoH);
-                    Shape repositionShape = ProtocolUtil.calculateWidgetInfoShape(canvas,minicwShape, miniwidgetInfoW, miniwidgetInfoH);
-                    if (repositionShape != minicwShape){
-                        double x = repositionShape.x() - repositionShape.width() - 32,
-                                y = repositionShape.y() - repositionShape.height() - 32;
-                        if (x < 0) x = 0; if (y < 0) y = 0;
-                        minicwShape = Rect.from(x,y,repositionShape.width(), repositionShape.height());
-                    }
-                    canvas.rect(Pen.PEN_WHITE_ALPHA, minicwShape.x(), minicwShape.y(), miniwidgetInfoW, miniwidgetInfoH);
-                    canvas.rect(Pen.PEN_BLACK, minicwShape.x(), minicwShape.y(), miniwidgetInfoW, miniwidgetInfoH);
-                    canvas.text(Pen.PEN_RED, minicwShape.x(), minicwShape.y(), 0, rootText);
-                    canvas.text(Pen.PEN_BLUE, minicwShape.x(), minicwShape.y() + 20, 0, idxText);
-                    canvas.text(Pen.PEN_BLUE, minicwShape.x(), minicwShape.y() + 40, 0, roleText);
-                    canvas.text(Pen.PEN_BLUE, minicwShape.x(), minicwShape.y() + 60, 0, widConcreteText);
+                	// Calculate the maximum length of the widget properties strings
+                	String[] textArray = {rootText, widgetText, titleText, roleText, enabledText, shapeText, pathText};
+                	int maxLength = 0;
+                	for (String text : textArray) {
+                		maxLength = Math.max(maxLength, text.length());
+                	}
+                	double miniwidgetInfoW = maxLength * 8.0;
+                	if (miniwidgetInfoW < 256) miniwidgetInfoW = 256;
+                	double miniwidgetInfoH = 20 * textArray.length; // Each property uses a height of 20
+
+                	// Create the Shape of the visual rectangles we draw in Spy mode
+                	Shape minicwShape = Rect.from(cwShape.x() + cwShape.width()/2 + 32,
+                			cwShape.y() + cwShape.height()/2 + 32,
+                			miniwidgetInfoW, miniwidgetInfoH);
+                	Shape repositionShape = ProtocolUtil.calculateWidgetInfoShape(canvas,minicwShape, miniwidgetInfoW, miniwidgetInfoH);
+                	if (repositionShape != minicwShape){
+                		double x = repositionShape.x() - repositionShape.width() - 32,
+                				y = repositionShape.y() - repositionShape.height() - 32;
+                		if (x < 0) x = 0; if (y < 0) y = 0;
+                		minicwShape = Rect.from(x,y,repositionShape.width(), repositionShape.height());
+                	}
+
+                	// Draw the rectangle and widget properties in the screen
+                	canvas.rect(Pen.PEN_WHITE_ALPHA, minicwShape.x(), minicwShape.y(), miniwidgetInfoW, miniwidgetInfoH);
+                	canvas.rect(Pen.PEN_BLACK, minicwShape.x(), minicwShape.y(), miniwidgetInfoW, miniwidgetInfoH);
+                	canvas.text(Pen.PEN_RED, minicwShape.x(), minicwShape.y(), 0, rootText);
+                	canvas.text(Pen.PEN_BLUE, minicwShape.x(), minicwShape.y() + 20, 0, widgetText);
+                	canvas.text(Pen.PEN_BLUE, minicwShape.x(), minicwShape.y() + 40, 0, titleText);
+                	canvas.text(Pen.PEN_BLUE, minicwShape.x(), minicwShape.y() + 60, 0, roleText);
+                	canvas.text(Pen.PEN_BLUE, minicwShape.x(), minicwShape.y() + 80, 0, enabledText);
+                	canvas.text(Pen.PEN_BLUE, minicwShape.x(), minicwShape.y() + 100, 0, shapeText);
+                	canvas.text(Pen.PEN_BLUE, minicwShape.x(), minicwShape.y() + 120, 0, pathText);
                 }
 
                 // TODO: Check if this is useful. If not, just remove it.

--- a/testar/src/org/testar/SutVisualization.java
+++ b/testar/src/org/testar/SutVisualization.java
@@ -94,7 +94,7 @@ public class SutVisualization {
                 	String titleText = "Title: " + cursorWidget.get(Tags.Title, "");
                 	String roleText = "Role: " + cursorWidget.get(Role, Roles.Widget).toString();
                 	String enabledText = "Enabled: " + cursorWidget.get(Tags.Enabled, false);
-                	String shapeText = "Shape: " + cursorWidget.get(Tags.Shape);
+                	String shapeText = "Shape: " + cursorWidget.get(Tags.Shape, Rect.from(0, 0, 0, 0));
                 	String pathText = "Path: " + cursorWidget.get(Tags.Path, "");
 
                 	// Calculate the maximum length of the widget properties strings

--- a/testar/src/org/testar/monkey/ConfigTags.java
+++ b/testar/src/org/testar/monkey/ConfigTags.java
@@ -221,7 +221,7 @@ public final class ConfigTags {
 			"Sets whether to display TESTAR dialog. If false is used, then TESTAR will run in the mode of the Mode property");
 
 	public static final Tag<Boolean> ForceForeground = Tag.from("ForceForeground", Boolean.class, 
-			"Sets whether to keep the SUT’s GUI active in the screen (e.g. when its minimised or when a process is started and its UI is in front, etc.)");
+			"Sets whether to keep the SUTs GUI active in the screen (e.g. when its minimised or when a process is started and its UI is in front, etc.)");
 
 	public static final Tag<Integer> LogLevel = Tag.from("LogLevel", Integer.class, 
 			"Sets the logging level to critical messages (0), information messages (1) or debug messages (2)");

--- a/testar/src/org/testar/monkey/ConfigTags.java
+++ b/testar/src/org/testar/monkey/ConfigTags.java
@@ -271,16 +271,18 @@ public final class ConfigTags {
 	public static final Tag<String> ProtocolCompileDirectory = Tag.from("ProtocolCompileDirectory", String.class, 
 			"The relative path on which compile the TESTAR protocols and create the class files");
 
+	public static final Tag<String> OutputDir = Tag.from("OutputDir", String.class, 
+			"The relative path to save TESTAR output results");
+
+	public static final Tag<String> TempDir = Tag.from("TempDir", String.class, 
+			"The relative path to temporarily  save TESTAR files");
+
 	public static final Tag<String> ReportingClass = Tag.from("ReportingClass", String.class, 
 			"Sets whether create a HTML or NUNIT report");
 
 	/**
 	 * Other settings
 	 */
-
-	public static final Tag<String> OutputDir = Tag.from("OutputDir", String.class);
-
-	public static final Tag<String> TempDir = Tag.from("TempDir", String.class);
 
 	public static final Tag<Double> FaultThreshold = Tag.from("FaultThreshold", Double.class);
 

--- a/testar/src/org/testar/monkey/ConfigTags.java
+++ b/testar/src/org/testar/monkey/ConfigTags.java
@@ -1,33 +1,32 @@
 /***************************************************************************************************
-*
-* Copyright (c) 2013 - 2022 Universitat Politecnica de Valencia - www.upv.es
-* Copyright (c) 2018 - 2022 Open Universiteit - www.ou.nl
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-* notice, this list of conditions and the following disclaimer in the
-* documentation and/or other materials provided with the distribution.
-* 3. Neither the name of the copyright holder nor the names of its
-* contributors may be used to endorse or promote products derived from
-* this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*******************************************************************************************************/
-
+ *
+ * Copyright (c) 2013 - 2023 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2018 - 2023 Open Universiteit - www.ou.nl
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************************************/
 
 package org.testar.monkey;
 
@@ -36,131 +35,266 @@ import org.testar.monkey.alayer.Tag;
 import java.util.List;
 
 public final class ConfigTags {
-  public static final Tag<String> ProcessesToKillDuringTest = Tag.from("ProcessesToKillDuringTest", String.class);
-  public static final Tag<Boolean> ShowVisualSettingsDialogOnStartup = Tag.from("ShowVisualSettingsDialogOnStartup", Boolean.class);
-  public static final Tag<Integer> LogLevel = Tag.from("LogLevel", Integer.class);
-  public static final Tag<String> SuspiciousTitles = Tag.from("SuspiciousTitles", String.class);
-  public static final Tag<String> ClickFilter = Tag.from("ClickFilter", String.class);
-  public static final Tag<String> OutputDir = Tag.from("OutputDir", String.class);
-  public static final Tag<String> TempDir = Tag.from("TempDir", String.class);
-  public static final Tag<Boolean> OnlySaveFaultySequences = Tag.from("OnlySaveFaultySequences", Boolean.class);
-  public static final Tag<Boolean> ForceForeground = Tag.from("ForceForeground", Boolean.class);
-  public static final Tag<Double> ActionDuration = Tag.from("ActionDuration", Double.class);
-  public static final Tag<Double> FaultThreshold = Tag.from("FaultThreshold", Double.class);
-  public static final Tag<Double> TimeToWaitAfterAction = Tag.from("TimeToWaitAfterAction", Double.class);
-  public static final Tag<Boolean> VisualizeActions = Tag.from("VisualizeActions", Boolean.class);
-  public static final Tag<Boolean> UseSystemActions = Tag.from("UseSystemActions", Boolean.class);
-  public static final Tag<Boolean> VisualizeSelectedAction = Tag.from("VisualizeSelectedAction", Boolean.class);
-  public static final Tag<Boolean> DrawWidgetUnderCursor = Tag.from("DrawWidgetUnderCursor", Boolean.class);
-  public static final Tag<Boolean> DrawWidgetInfo = Tag.from("DrawWidgetInfo", Boolean.class);
-  public static final Tag<Boolean> ExecuteActions = Tag.from("ExecuteActions", Boolean.class);
-  public static final Tag<String> PathToReplaySequence = Tag.from("PathToReplaySequence", String.class);
-  public static final Tag<RuntimeControlsProtocol.Modes> Mode = Tag.from("Mode", RuntimeControlsProtocol.Modes.class);
-  public static final Tag<String> SUTConnectorValue = Tag.from("SUTConnectorValue", String.class);
-  public static final Tag<Integer> SequenceLength = Tag.from("SequenceLength", Integer.class);
-  public static final Tag<Integer> Sequences = Tag.from("Sequences", Integer.class);
-  public static final Tag<Double> ReplayRetryTime = Tag.from("ReplayRetryTime", Double.class);
-  public static final Tag<Double> MaxTime = Tag.from("MaxTime", Double.class);
-  public static final Tag<Double> StartupTime = Tag.from("StartupTime", Double.class);
-  @SuppressWarnings("unchecked")
-  public static final Tag<List<String>> Delete = Tag.from("Delete", (Class<List<String>>) (Class<?>) List.class);
-  @SuppressWarnings("unchecked")
-  public static final Tag<List<Pair<String, String>>> CopyFromTo = Tag.from("CopyFromTo", (Class<List<Pair<String, String>>>) (Class<?>) List.class);
-  @SuppressWarnings("unchecked")
-  public static final Tag<List<String>> MyClassPath = Tag.from("MyClassPath", (Class<List<String>>) (Class<?>) List.class);
-  public static final Tag<String> ProtocolClass = Tag.from("ProtocolClass", String.class);
-  public static final Tag<Boolean> UseRecordedActionDurationAndWaitTimeDuringReplay = Tag.from("UseRecordedActionDurationAndWaitTimeDuringReplay", Boolean.class);
-  public static final Tag<Boolean> StopGenerationOnFault = Tag.from("StopGenerationOnFault", Boolean.class);
-  public static final Tag<Double> TimeToFreeze = Tag.from("TimeToFreeze", Double.class);
-  public static final Tag<Boolean> ShowSettingsAfterTest = Tag.from("ShowSettingsAfterTest", Boolean.class);
-  public static final Tag<Double> RefreshSpyCanvas = Tag.from("RefreshSpyCanvas", Double.class);
 
-  public static final Tag<String> SUTConnector = Tag.from("SUTConnector", String.class);
-  public static final Tag<String> TestGenerator = Tag.from("TestGenerator", String.class);
-  public static final Tag<Double> MaxReward = Tag.from("MaxReward", Double.class);
-  public static final Tag<Double> Discount = Tag.from("Discount", Double.class);
-  public static final Tag<Boolean> AlgorithmFormsFilling = Tag.from("AlgorithmFormsFilling", Boolean.class);
-  public static final Tag<Integer> TypingTextsForExecutedAction = Tag.from("TypingTextsForExecutedAction", Integer.class);
-  public static final Tag<Boolean> DrawWidgetTree = Tag.from("DrawWidgetTree", Boolean.class);
-  public static final Tag<Integer> ExplorationSampleInterval = Tag.from("ExplorationSampleInterval", Integer.class);
-  public static final Tag<Boolean> ForceToSequenceLength = Tag.from("ForceToSequenceLength", Boolean.class);
-  public static final Tag<Integer> NonReactingUIThreshold = Tag.from("NonReactingUIThreshold", Integer.class);
-  public static final Tag<Boolean> OfflineGraphConversion = Tag.from("OfflineGraphConversion", Boolean.class);
-  public static final Tag<Float> StateScreenshotSimilarityThreshold = Tag.from("StateScreenshotSimilarityThreshold", Float.class);
-  public static final Tag<Boolean> UnattendedTests = Tag.from("UnattendedTests", Boolean.class);
-  public static final Tag<Boolean> AccessBridgeEnabled = Tag.from("AccessBridgeEnabled", Boolean.class);
-  public static final Tag<String> SUTProcesses = Tag.from("SUTProcesses", String.class); // Shift+0 shortcut to debug (STDOUT) windows' process names
+	private ConfigTags() {}
 
+	public static final Tag<RuntimeControlsProtocol.Modes> Mode = Tag.from("Mode", RuntimeControlsProtocol.Modes.class, 
+			"Set the mode you want TESTAR to start in: Spy, Generate, Replay");
 
-  public static final Tag<Boolean> CreateWidgetInfoJsonFile = Tag.from("CreateWidgetInfoJsonFile", Boolean.class);
-  public static final Tag<Boolean> FormFillingAction = Tag.from("FormFillingAction", Boolean.class);
+	public static final Tag<String> SUTConnector = Tag.from("SUTConnector", String.class, 
+			"Indicate how you want to connect to the SUT: COMMAND_LINE, SUT_WINDOW_TITLE, SUT_PROCESS_NAME");
 
-  // state model config tags
-  public static final Tag<Boolean> StateModelEnabled = Tag.from("StateModelEnabled", Boolean.class);
-  public static final Tag<String> DataStore = Tag.from("DataStore", String.class);
-  public static final Tag<String> DataStoreType = Tag.from("DataStoreType", String.class);
-  public static final Tag<String> DataStoreServer = Tag.from("DataStoreServer", String.class);
-  public static final Tag<String> DataStoreDB = Tag.from("DataStoreDB", String.class);
-  public static final Tag<String> DataStoreUser = Tag.from("DataStoreUser", String.class);
-  public static final Tag<String> DataStorePassword = Tag.from("DataStorePassword", String.class);
-  public static final Tag<String> DataStoreMode = Tag.from("DataStoreMode", String.class);
-  public static final Tag<String> DataStoreDirectory = Tag.from("DataStoreDirectory", String.class);
-  public static final Tag<Boolean> ResetDataStore = Tag.from("ResetDataStore", Boolean.class);
-  public static final Tag<String> ApplicationName = Tag.from("ApplicationName", String.class);
-  public static final Tag<String> ApplicationVersion = Tag.from("ApplicationVersion", String.class);
-  public static final Tag<String> ActionSelectionAlgorithm = Tag.from("ActionSelectionAlgorithm", String.class);
-  public static final Tag<Boolean> StateModelStoreWidgets = Tag.from("StateModelStoreWidgets", Boolean.class);
-  @SuppressWarnings("unchecked")
-  public static final Tag<List<String>> AbstractStateAttributes = Tag.from("AbstractStateAttributes", (Class<List<String>>) (Class<?>) List.class);
+	public static final Tag<String> SUTConnectorValue = Tag.from("SUTConnectorValue", String.class, 
+			"The connector value: executable path, windows title, process name");
 
-  public static final Tag<Boolean> AlwaysCompile = Tag.from("AlwaysCompile", Boolean.class);
+	public static final Tag<Boolean> AccessBridgeEnabled = Tag.from("AccessBridgeEnabled", Boolean.class, 
+			"Enable Java Access Bridge to test Java Swing applications");
 
-  public static final Tag<Boolean> ProcessListenerEnabled = Tag.from("ProcessListenerEnabled", Boolean.class);
-  public static final Tag<String> SuspiciousProcessOutput = Tag.from("SuspiciousProcessOutput", String.class);
-  public static final Tag<String> ProcessLogs = Tag.from("ProcessLogs", String.class);
+	public static final Tag<Integer> Sequences = Tag.from("Sequences", Integer.class, 
+			"Number of times to repeat a test");
 
-  // Note: Defined the tag as string on purpose so we can leave the default value empty in the pre defined settings.
-  public static final Tag<String> OverrideWebDriverDisplayScale = Tag.from("OverrideWebDriverDisplayScale", String.class);
+	public static final Tag<Integer> SequenceLength = Tag.from("SequenceLength", Integer.class, 
+			"For each test sequence, the number of GUI actions to perform");
 
-  public static final Tag<String> ExtendedSettingsFile = Tag.from("ExtendedSettingsFile", String.class);
+	public static final Tag<String> SuspiciousTags = Tag.from("SuspiciousTags", String.class, 
+			"Regular expressions ORACLE to find suspicious messages in the GUI Tags");
 
-  // 5 settings that can be used in user specified TESTAR protocols for anything:
-  public static final Tag<String> ProtocolSpecificSetting_1 = Tag.from("ProtocolSpecificSetting_1", String.class);
-  public static final Tag<String> ProtocolSpecificSetting_2 = Tag.from("ProtocolSpecificSetting_2", String.class);
-  public static final Tag<String> ProtocolSpecificSetting_3 = Tag.from("ProtocolSpecificSetting_3", String.class);
-  public static final Tag<String> ProtocolSpecificSetting_4 = Tag.from("ProtocolSpecificSetting_4", String.class);
-  public static final Tag<String> ProtocolSpecificSetting_5 = Tag.from("ProtocolSpecificSetting_5", String.class);
+	@SuppressWarnings("unchecked")
+	public static final Tag<List<String>> TagsForSuspiciousOracle = Tag.from("TagsForSuspiciousOracle", (Class<List<String>>) (Class<?>) List.class, 
+			"The Tags to apply the SuspiciousTags regex expressions");
 
-  // WebDriver specific settings:
-  @SuppressWarnings("unchecked")
-  public static final Tag<List<String>> ClickableClasses = Tag.from("ClickableClasses", (Class<List<String>>) (Class<?>) List.class);
-  @SuppressWarnings("unchecked")
-  public static final Tag<List<String>> DeniedExtensions = Tag.from("DeniedExtensions", (Class<List<String>>) (Class<?>) List.class);
-  @SuppressWarnings("unchecked")
-  public static final Tag<List<String>> DomainsAllowed = Tag.from("DomainsAllowed", (Class<List<String>>) (Class<?>) List.class);
-  @SuppressWarnings("unchecked")
-  public static final Tag<List<String>> TagsToFilter = Tag.from("TagsToFilter", (Class<List<String>>) (Class<?>) List.class);
-  @SuppressWarnings("unchecked")
-  public static final Tag<List<String>> TagsForSuspiciousOracle = Tag.from("TagsForSuspiciousOracle", (Class<List<String>>) (Class<?>) List.class);
-  public static final Tag<Boolean> FollowLinks = Tag.from("FollowLinks", Boolean.class);
-  public static final Tag<Boolean> BrowserFullScreen = Tag.from("BrowserFullScreen", Boolean.class);
-  public static final Tag<Boolean> SwitchNewTabs = Tag.from("SwitchNewTabs", Boolean.class);
+	public static final Tag<Boolean> ProcessListenerEnabled = Tag.from("ProcessListenerEnabled", Boolean.class, 
+			"Enable  the feature to read the process buffer of the SUT (Only for desktop applications through COMMAND_LINE)");
 
-  // Oracles for webdriver browser console
-  public static final Tag<Boolean> WebConsoleErrorOracle = Tag.from("WebConsoleErrorOracle", Boolean.class);
-  public static final Tag<String> WebConsoleErrorPattern = Tag.from("WebConsoleErrorPattern", String.class);
-  public static final Tag<Boolean> WebConsoleWarningOracle = Tag.from("WebConsoleWarningOracle", Boolean.class);
-  public static final Tag<String> WebConsoleWarningPattern = Tag.from("WebConsoleWarningPattern", String.class);
+	public static final Tag<String> SuspiciousProcessOutput = Tag.from("SuspiciousProcessOutput", String.class, 
+			"Regular expressions ORACLE to find suspicious messages in the process buffer of the SUT");
 
-  public static final Tag<Boolean> FlashFeedback = Tag.from("FlashFeedback", Boolean.class);
-  public static final Tag<String> ProtocolCompileDirectory = Tag.from("ProtocolCompileDirectory", String.class);
-  public static final Tag<String> ReportingClass = Tag.from("ReportingClass", String.class);
+	public static final Tag<String> ProcessLogs = Tag.from("ProcessLogs", String.class, 
+			"Regular expressions to store execution logs coming from the processes");
 
-  /*
-  //TODO web driver settings for login feature
-  public static final Tag<Pair<String, String>> Login = Tag.from("Login", (Class<Pair<String, String>>) (Class<?>) Pair.class);
-  // Pair.from("https://login.awo.ou.nl/SSO/login", "OUinloggen");
-  public static final Tag<Pair<String, String>> Username = Tag.from("Username", (Class<Pair<String, String>>) (Class<?>) Pair.class);
-  public static final Tag<Pair<String, String>> Password = Tag.from("Password", (Class<Pair<String, String>>) (Class<?>) Pair.class);
-  */
+	public static final Tag<String> ClickFilter = Tag.from("ClickFilter", String.class, 
+			"Regular expressions to FILTER GUI widgets");
+
+	@SuppressWarnings("unchecked")
+	public static final Tag<List<String>> TagsToFilter = Tag.from("TagsToFilter", (Class<List<String>>) (Class<?>) List.class, 
+			"The Tags to apply the ClickFilter regex expressions");
+
+	public static final Tag<String> ProcessesToKillDuringTest = Tag.from("ProcessesToKillDuringTest", String.class, 
+			"Regular expressions to kill processes that can start up and interfere when testing the SUT");
+
+	public static final Tag<String> ProtocolClass = Tag.from("ProtocolClass", String.class, 
+			"Indicate the location of the protocol class for your specific SUT");
+
+	/**
+	 * State Model settings 
+	 */
+
+	public static final Tag<String> ApplicationName = Tag.from("ApplicationName", String.class, 
+			"Name to identify the SUT. Especially important to identify a State Model");
+
+	public static final Tag<String> ApplicationVersion = Tag.from("ApplicationVersion", String.class, 
+			"Version to identify the SUT. Especially important to identify a State Model");
+
+	public static final Tag<Boolean> StateModelEnabled = Tag.from("StateModelEnabled", Boolean.class, 
+			"Enable or disable the State Model feature");
+
+	public static final Tag<String> DataStore = Tag.from("DataStore", String.class, 
+			"The graph database we use to store the State Model: OrientDB");
+
+	public static final Tag<String> DataStoreType = Tag.from("DataStoreType", String.class, 
+			"The mode we use to connect to the database: remote or plocal");
+
+	public static final Tag<String> DataStoreServer = Tag.from("DataStoreServer", String.class, 
+			"IP address to connect if we desired to use remote mode");
+
+	public static final Tag<String> DataStoreDirectory = Tag.from("DataStoreDirectory", String.class, 
+			"Path of the directory on which local OrientDB exists, if we use plocal mode");
+
+	public static final Tag<String> DataStoreDB = Tag.from("DataStoreDB", String.class, 
+			"The name of the desired database on which we want to store the State Model.");
+
+	public static final Tag<String> DataStoreUser = Tag.from("DataStoreUser", String.class, 
+			"User credential to authenticate TESTAR in OrientDB");
+
+	public static final Tag<String> DataStorePassword = Tag.from("DataStorePassword", String.class, 
+			"Password credential to authenticate TESTAR in OrientDB");
+
+	public static final Tag<String> DataStoreMode = Tag.from("DataStoreMode", String.class, 
+			"Indicate how TESTAR should store the model objects in the database: instant, delayed, hybrid, none");
+
+	public static final Tag<String> ActionSelectionAlgorithm = Tag.from("ActionSelectionAlgorithm", String.class, 
+			"State Model Action Selection mechanism to explore the SUT: random or unvisited");
+
+	public static final Tag<Boolean> StateModelStoreWidgets = Tag.from("StateModelStoreWidgets", Boolean.class, 
+			"Save all widget tree information in the State Model every time TESTAR discovers a new Concrete State");
+
+	public static final Tag<Boolean> ResetDataStore = Tag.from("ResetDataStore", Boolean.class, 
+			"WARNING: Delete all existing State Models from the selected database before creating a new one");
+
+	@SuppressWarnings("unchecked")
+	public static final Tag<List<String>> AbstractStateAttributes = Tag.from("AbstractStateAttributes", (Class<List<String>>) (Class<?>) List.class, 
+			"Specify the widget attributes that you wish to use in constructing the widget and state hash strings. Use a comma separated list.");
+
+	/**
+	 * WebDriver settings 
+	 */
+
+	@SuppressWarnings("unchecked")
+	public static final Tag<List<String>> ClickableClasses = Tag.from("ClickableClasses", (Class<List<String>>) (Class<?>) List.class, 
+			"Indicate which web CSS classes need to be considered clickable");
+
+	@SuppressWarnings("unchecked")
+	public static final Tag<List<String>> DeniedExtensions = Tag.from("DeniedExtensions", (Class<List<String>>) (Class<?>) List.class, 
+			"Indicate which web URL extensions need to be ignored when testing");
+
+	@SuppressWarnings("unchecked")
+	public static final Tag<List<String>> DomainsAllowed = Tag.from("DomainsAllowed", (Class<List<String>>) (Class<?>) List.class, 
+			"Indicate which web URL domains need to be ignored when testing");
+
+	public static final Tag<Boolean> FollowLinks = Tag.from("FollowLinks", Boolean.class, 
+			"Indicate if allowing to follow links opened in new tabs");
+
+	public static final Tag<Boolean> BrowserFullScreen = Tag.from("BrowserFullScreen", Boolean.class, 
+			"Indicate if perform the web testing with the browser in full screen");
+
+	public static final Tag<Boolean> SwitchNewTabs = Tag.from("SwitchNewTabs", Boolean.class, 
+			"Indicate if switch to a new web tab if opened");
+
+	public static final Tag<Boolean> WebConsoleErrorOracle = Tag.from("WebConsoleErrorOracle", Boolean.class, 
+			"Enable or Disable applying ORACLES to the browser error console");
+
+	public static final Tag<String> WebConsoleErrorPattern = Tag.from("WebConsoleErrorPattern", String.class, 
+			"Regular expressions ORACLE to find suspicious messages in the browser error console");
+
+	public static final Tag<Boolean> WebConsoleWarningOracle = Tag.from("WebConsoleWarningOracle", Boolean.class, 
+			"Enable or Disable applying ORACLES to the browser warning console");
+
+	public static final Tag<String> WebConsoleWarningPattern = Tag.from("WebConsoleWarningPattern", String.class, 
+			"Regular expressions ORACLE to find suspicious messages in the browser warning console");
+
+	// Note: Defined the tag as string on purpose so we can leave the default value empty in the pre defined settings.
+	public static final Tag<String> OverrideWebDriverDisplayScale = Tag.from("OverrideWebDriverDisplayScale", String.class, 
+			"Overrides the displayscale obtained from the system for web SUTs");
+
+	public static final Tag<String> ExtendedSettingsFile = Tag.from("ExtendedSettingsFile", String.class, 
+			"Relative path to extended XML settings file");
+
+	// 5 settings that can be used in user specified TESTAR protocols for anything:
+	public static final Tag<String> ProtocolSpecificSetting_1 = Tag.from("ProtocolSpecificSetting_1", String.class, 
+			"Settings (string) that can be used for user specified protocols");
+	public static final Tag<String> ProtocolSpecificSetting_2 = Tag.from("ProtocolSpecificSetting_2", String.class, 
+			"Settings (string) that can be used for user specified protocols");
+	public static final Tag<String> ProtocolSpecificSetting_3 = Tag.from("ProtocolSpecificSetting_3", String.class, 
+			"Settings (string) that can be used for user specified protocols");
+	public static final Tag<String> ProtocolSpecificSetting_4 = Tag.from("ProtocolSpecificSetting_4", String.class, 
+			"Settings (string) that can be used for user specified protocols");
+	public static final Tag<String> ProtocolSpecificSetting_5 = Tag.from("ProtocolSpecificSetting_5", String.class, 
+			"Settings (string) that can be used for user specified protocols");
+
+	/**
+	 * Additional settings with descriptions
+	 */
+
+	public static final Tag<Double> ActionDuration = Tag.from("ActionDuration", Double.class, 
+			"Sets the speed, in seconds, at which a GUI action is performed");
+
+	public static final Tag<Double> TimeToWaitAfterAction = Tag.from("TimeToWaitAfterAction", Double.class, 
+			"Sets the delay, in seconds, between UI actions during a test");
+
+	public static final Tag<Double> StartupTime = Tag.from("StartupTime", Double.class, 
+			"Sets how many seconds to wait for the SUT to be ready for testing");
+
+	public static final Tag<Double> MaxTime = Tag.from("MaxTime", Double.class, 
+			"Sets a time, in seconds, after which the test run is finished (e.g. stop after an hour)");
+
+	public static final Tag<Boolean> FormFillingAction = Tag.from("FormFillingAction", Boolean.class, 
+			"Enables or disables a specific web action that populate data in web forms");
+
+	public static final Tag<String> SUTProcesses = Tag.from("SUTProcesses", String.class, 
+			"Regular expressions that indicates which processes conform the SUT");
+
+	public static final Tag<Boolean> ShowVisualSettingsDialogOnStartup = Tag.from("ShowVisualSettingsDialogOnStartup", Boolean.class, 
+			"Sets whether to display TESTAR dialog. If false is used, then TESTAR will run in the mode of the Mode property");
+
+	public static final Tag<Boolean> ForceForeground = Tag.from("ForceForeground", Boolean.class, 
+			"Sets whether to keep the SUT’s GUI active in the screen (e.g. when its minimised or when a process is started and its UI is in front, etc.)");
+
+	public static final Tag<Integer> LogLevel = Tag.from("LogLevel", Integer.class, 
+			"Sets the logging level to critical messages (0), information messages (1) or debug messages (2)");
+
+	public static final Tag<Boolean> OnlySaveFaultySequences = Tag.from("OnlySaveFaultySequences", Boolean.class, 
+			"Sets whether to save test sequences without failures");
+
+	public static final Tag<Double> ReplayRetryTime = Tag.from("ReplayRetryTime", Double.class, 
+			"Inside the replay mode, establishes the time window in seconds for trying to replay a UI action of a replayed test sequence");
+
+	public static final Tag<Boolean> StopGenerationOnFault = Tag.from("StopGenerationOnFault", Boolean.class, 
+			"Sets whether to finish a test in the presence of a fail (e.g. Suspicious Tag detected)");
+
+	public static final Tag<Double> TimeToFreeze = Tag.from("TimeToFreeze", Double.class, 
+			"Sets the time window, in seconds, for which to wait for a not responding SUT. After that, the test will finish with a fail");
+
+	public static final Tag<Boolean> UseRecordedActionDurationAndWaitTimeDuringReplay = Tag.from("UseRecordedActionDurationAndWaitTimeDuringReplay", Boolean.class, 
+			"Inside the replay mode sets whether to use the action duration (ActionDuration and TimeToWaitAfterAction) as specified in the generated test sequence");
+
+	public static final Tag<Boolean> VisualizeActions = Tag.from("VisualizeActions", Boolean.class, 
+			"Sets whether to display overlay information, inside the SPY mode, for all the UI actions derived from the test set up");
+
+	public static final Tag<Boolean> UseSystemActions = Tag.from("UseSystemActions", Boolean.class, 
+			"ANDROID: Indicate if add system calls");
+
+	public static final Tag<String> PathToReplaySequence = Tag.from("PathToReplaySequence", String.class, 
+			"The sequence to REPLAY is the one indicated in this parameter");
+
+	public static final Tag<Double> RefreshSpyCanvas = Tag.from("RefreshSpyCanvas", Double.class, 
+			"Time in milliseconds that indicates the frequency of refreshing the screen in SPY mode");
+
+	public static final Tag<Boolean> AlwaysCompile = Tag.from("AlwaysCompile", Boolean.class, 
+			"Compile the protocol before launching the selected TESTAR mode");
+
+	public static final Tag<Boolean> FlashFeedback = Tag.from("FlashFeedback", Boolean.class, 
+			"Sets whether to draw a feedback message in the top-left corner of the screen");
+
+	public static final Tag<Double> MaxReward = Tag.from("MaxReward", Double.class, 
+			"MaxReward value for the QLearningActionSelector");
+
+	public static final Tag<Double> Discount = Tag.from("Discount", Double.class, 
+			"Discount value for the QLearningActionSelector");
+
+	public static final Tag<Boolean> CreateWidgetInfoJsonFile = Tag.from("CreateWidgetInfoJsonFile", Boolean.class, 
+			"Sets whether create a JSON file with information about widgets and their location on the screenshot");
+
+	@SuppressWarnings("unchecked")
+	public static final Tag<List<String>> MyClassPath = Tag.from("MyClassPath", (Class<List<String>>) (Class<?>) List.class, 
+			"The relative path that contains the TESTAR protocols");
+
+	public static final Tag<String> ProtocolCompileDirectory = Tag.from("ProtocolCompileDirectory", String.class, 
+			"The relative path on which compile the TESTAR protocols and create the class files");
+
+	public static final Tag<String> ReportingClass = Tag.from("ReportingClass", String.class, 
+			"Sets whether create a HTML or NUNIT report");
+
+	/**
+	 * Other settings
+	 */
+
+	public static final Tag<String> OutputDir = Tag.from("OutputDir", String.class);
+
+	public static final Tag<String> TempDir = Tag.from("TempDir", String.class);
+
+	public static final Tag<Double> FaultThreshold = Tag.from("FaultThreshold", Double.class);
+
+	@SuppressWarnings("unchecked")
+	public static final Tag<List<String>> Delete = Tag.from("Delete", (Class<List<String>>) (Class<?>) List.class);
+
+	@SuppressWarnings("unchecked")
+	public static final Tag<List<Pair<String, String>>> CopyFromTo = Tag.from("CopyFromTo", (Class<List<Pair<String, String>>>) (Class<?>) List.class);
+
+	/*
+	//TODO web driver settings for login feature
+	public static final Tag<Pair<String, String>> Login = Tag.from("Login", (Class<Pair<String, String>>) (Class<?>) Pair.class);
+	// Pair.from("https://login.awo.ou.nl/SSO/login", "OUinloggen");
+	public static final Tag<Pair<String, String>> Username = Tag.from("Username", (Class<Pair<String, String>>) (Class<?>) Pair.class);
+	public static final Tag<Pair<String, String>> Password = Tag.from("Password", (Class<Pair<String, String>>) (Class<?>) Pair.class);
+	 */
 }

--- a/testar/src/org/testar/monkey/DefaultProtocol.java
+++ b/testar/src/org/testar/monkey/DefaultProtocol.java
@@ -340,7 +340,7 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 		}
 
 		try {
-			if (!settings.get(ConfigTags.UnattendedTests) && !GraphicsEnvironment.isHeadless()) {
+			if (!GraphicsEnvironment.isHeadless()) {
 				LogSerialiser.log("Registering keyboard and mouse hooks\n", LogSerialiser.LogLevel.Debug);
 				java.util.logging.Logger logger = java.util.logging.Logger.getLogger(GlobalScreen.class.getPackage().getName());
 				logger.setLevel(Level.OFF);
@@ -848,7 +848,7 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 		//------------------------
 
 		if (this.suspiciousTitlesPattern == null)
-			this.suspiciousTitlesPattern = Pattern.compile(settings().get(ConfigTags.SuspiciousTitles), Pattern.UNICODE_CHARACTER_CLASS);
+			this.suspiciousTitlesPattern = Pattern.compile(settings().get(ConfigTags.SuspiciousTags), Pattern.UNICODE_CHARACTER_CLASS);
 
 		// search all widgets for suspicious String Values
 		Verdict suspiciousValueVerdict = Verdict.OK;
@@ -1130,7 +1130,7 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 	private void closeTestarTestSession(){
 		//cleaning the variables started in initialize()
 		try {
-			if (!settings.get(ConfigTags.UnattendedTests) && !GraphicsEnvironment.isHeadless()) {
+			if (!GraphicsEnvironment.isHeadless()) {
 				if (GlobalScreen.isNativeHookRegistered()) {
 					LogSerialiser.log("Unregistering keyboard and mouse hooks\n", LogSerialiser.LogLevel.Debug);
 					GlobalScreen.removeNativeMouseMotionListener(eventHandler);

--- a/testar/src/org/testar/monkey/DefaultProtocol.java
+++ b/testar/src/org/testar/monkey/DefaultProtocol.java
@@ -835,9 +835,9 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 		// ORACLES FOR FREE
 		//-------------------
 
-		// if the SUT is not running, we assume it crashed
+		// if the SUT is not running and closed unexpectedly, we assume it crashed
 		if(!state.get(IsRunning, false))
-			return new Verdict(Verdict.SEVERITY_NOT_RUNNING, "System is offline! I assume it crashed!");
+			return new Verdict(Verdict.SEVERITY_UNEXPECTEDCLOSE, "System is offline! Closed Unexpectedly! I assume it crashed!");
 
 		// if the SUT does not respond within a given amount of time, we assume it crashed
 		if(state.get(Tags.NotResponding, false)){

--- a/testar/src/org/testar/monkey/DefaultProtocol.java
+++ b/testar/src/org/testar/monkey/DefaultProtocol.java
@@ -854,7 +854,7 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 		Verdict suspiciousValueVerdict = Verdict.OK;
 		for(Widget w : state) {
 			suspiciousValueVerdict = suspiciousStringValueMatcher(w);
-			if(suspiciousValueVerdict.severity() == Verdict.SEVERITY_SUSPICIOUS_TITLE) {
+			if(suspiciousValueVerdict.severity() == Verdict.SEVERITY_SUSPICIOUS_TAG) {
 				return suspiciousValueVerdict;
 			}
 		}
@@ -898,8 +898,8 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 				Pen RedPen = Pen.newPen().setColor(Color.Red).setFillPattern(FillPattern.None).setStrokePattern(StrokePattern.Solid).build();
 				// visualize the problematic widget, by marking it with a red box
 				if(w.get(Tags.Shape, null) != null)
-					visualizer = new ShapeVisualizer(RedPen, w.get(Tags.Shape), "Suspicious Title", 0.5, 0.5);
-				return new Verdict(Verdict.SEVERITY_SUSPICIOUS_TITLE,
+					visualizer = new ShapeVisualizer(RedPen, w.get(Tags.Shape), "Suspicious Tag", 0.5, 0.5);
+				return new Verdict(Verdict.SEVERITY_SUSPICIOUS_TAG,
 						"Discovered suspicious widget '" + tagForSuspiciousOracle + "' : '" + tagValue + "'.", visualizer);
 			}
 		}

--- a/testar/src/org/testar/monkey/Main.java
+++ b/testar/src/org/testar/monkey/Main.java
@@ -316,10 +316,6 @@ public class Main {
 
 		// Override the settings by checking the JVM arguments
 		overrideWithUserProperties(settings);
-		Float SST = settings.get(ConfigTags.StateScreenshotSimilarityThreshold, null);
-		if (SST != null) {
-			System.setProperty("SCRSHOT_SIMILARITY_THRESHOLD", SST.toString());
-		}
 
 		return settings;
 	}
@@ -461,11 +457,7 @@ public class Main {
 			defaults.add(Pair.from(PathToReplaySequence, tempDir));
 			defaults.add(Pair.from(ActionDuration, 0.1));
 			defaults.add(Pair.from(TimeToWaitAfterAction, 0.1));
-			defaults.add(Pair.from(ExecuteActions, true));
-			defaults.add(Pair.from(DrawWidgetUnderCursor, false));
-			defaults.add(Pair.from(DrawWidgetInfo, true));
 			defaults.add(Pair.from(VisualizeActions, false));
-			defaults.add(Pair.from(VisualizeSelectedAction, false));
 			defaults.add(Pair.from(SequenceLength, 10));
 			defaults.add(Pair.from(ReplayRetryTime, 30.0));
 			defaults.add(Pair.from(Sequences, 1));
@@ -474,7 +466,7 @@ public class Main {
 			defaults.add(Pair.from(SUTConnectorValue, ""));
 			defaults.add(Pair.from(Delete, new ArrayList<String>()));
 			defaults.add(Pair.from(CopyFromTo, new ArrayList<Pair<String, String>>()));
-			defaults.add(Pair.from(SuspiciousTitles, "(?!x)x"));
+			defaults.add(Pair.from(SuspiciousTags, "(?!x)x"));
 			defaults.add(Pair.from(ClickFilter, "(?!x)x"));
 			defaults.add(Pair.from(MyClassPath, Arrays.asList(settingsDir)));
 			defaults.add(Pair.from(ProtocolClass, "org.testar.monkey.DefaultProtocol"));
@@ -482,22 +474,11 @@ public class Main {
 			defaults.add(Pair.from(UseRecordedActionDurationAndWaitTimeDuringReplay, true));
 			defaults.add(Pair.from(StopGenerationOnFault, true));
 			defaults.add(Pair.from(TimeToFreeze, 10.0));
-			defaults.add(Pair.from(ShowSettingsAfterTest, true));
 			defaults.add(Pair.from(RefreshSpyCanvas, 0.5));
 			defaults.add(Pair.from(SUTConnector, Settings.SUT_CONNECTOR_CMDLINE));
-			defaults.add(Pair.from(TestGenerator, "random"));
 			defaults.add(Pair.from(MaxReward, 9999999.0));
 			defaults.add(Pair.from(Discount, .95));
-			defaults.add(Pair.from(AlgorithmFormsFilling, false));
-			defaults.add(Pair.from(TypingTextsForExecutedAction, 10));
-			defaults.add(Pair.from(DrawWidgetTree, false));
-			defaults.add(Pair.from(ExplorationSampleInterval, 1));
-			defaults.add(Pair.from(ForceToSequenceLength, true));
-			defaults.add(Pair.from(NonReactingUIThreshold, 100)); // number of executed actions
-			defaults.add(Pair.from(OfflineGraphConversion, true));
-			defaults.add(Pair.from(StateScreenshotSimilarityThreshold, Float.MIN_VALUE)); // disabled
-			defaults.add(Pair.from(UnattendedTests, false)); // disabled
-			defaults.add(Pair.from(AccessBridgeEnabled, false)); // disabled
+			defaults.add(Pair.from(AccessBridgeEnabled, false));
 			defaults.add(Pair.from(SUTProcesses, ""));
 			defaults.add(Pair.from(StateModelEnabled, false));
 			defaults.add(Pair.from(DataStore, ""));
@@ -686,16 +667,6 @@ public class Main {
 			settings.set(ConfigTags.ShowVisualSettingsDialogOnStartup, !(new Boolean(p).booleanValue()));
 			LogSerialiser.log("Property <" + pS + "> overridden to <" + p + ">", LogSerialiser.LogLevel.Critical);
 		}
-		// TestGenerator
-		pS = ConfigTags.TestGenerator.name();
-		p = System.getProperty(pS, null);
-		if (p == null) {
-			p = System.getProperty("TG", null); // mnemonic
-		}
-		if (p != null) {
-			settings.set(ConfigTags.TestGenerator, p);
-			LogSerialiser.log("Property <" + pS + "> overridden to <" + p + ">", LogSerialiser.LogLevel.Critical);
-		}
 		// SequenceLength
 		pS = ConfigTags.SequenceLength.name();
 		p = System.getProperty(pS, null);
@@ -710,56 +681,6 @@ public class Main {
 			} catch (NumberFormatException e) {
 				LogSerialiser.log("Property <" + pS + "> could not be set! (using default)", LogSerialiser.LogLevel.Critical);
 			}
-		}
-		// ForceToSequenceLength
-		pS = ConfigTags.ForceToSequenceLength.name();
-		p = System.getProperty(pS, null);
-		if (p == null) {
-			p = System.getProperty("F2SL", null); // mnemonic
-		}
-		if (p != null) {
-			settings.set(ConfigTags.ForceToSequenceLength, new Boolean(p).booleanValue());
-			LogSerialiser.log("Property <" + pS + "> overridden to <" + p + ">", LogSerialiser.LogLevel.Critical);
-		}
-		// TypingTextsForExecutedAction
-		pS = ConfigTags.TypingTextsForExecutedAction.name();
-		p = System.getProperty(pS, null);
-		if (p == null) {
-			p = System.getProperty("TT", null); // mnemonic
-		}
-		if (p != null) {
-			try {
-				Integer tt = new Integer(p);
-				settings.set(ConfigTags.TypingTextsForExecutedAction, tt);
-				LogSerialiser.log("Property <" + pS + "> overridden to <" + tt.toString() + ">", LogSerialiser.LogLevel.Critical);
-			} catch (NumberFormatException e) {
-				LogSerialiser.log("Property <" + pS + "> could not be set! (using default)", LogSerialiser.LogLevel.Critical);
-			}
-		}
-		// StateScreenshotSimilarityThreshold
-		pS = ConfigTags.StateScreenshotSimilarityThreshold.name();
-		p = System.getProperty(pS, null);
-		if (p == null) {
-			p = System.getProperty("SST", null); // mnemonic
-		}
-		if (p != null) {
-			try {
-				Float sst = new Float(p);
-				settings.set(ConfigTags.StateScreenshotSimilarityThreshold, sst);
-				LogSerialiser.log("Property <" + pS + "> overridden to <" + sst.toString() + ">", LogSerialiser.LogLevel.Critical);
-			} catch (NumberFormatException e) {
-				LogSerialiser.log("Property <" + pS + "> could not be set! (using default)", LogSerialiser.LogLevel.Critical);
-			}
-		}
-		// UnattendedTests
-		pS = ConfigTags.UnattendedTests.name();
-		p = System.getProperty(pS, null);
-		if (p == null) {
-			p = System.getProperty("UT", null); // mnemonic
-		}
-		if (p != null) {
-			settings.set(ConfigTags.UnattendedTests, new Boolean(p).booleanValue());
-			LogSerialiser.log("Property <" + pS + "> overridden to <" + p + ">", LogSerialiser.LogLevel.Critical);
 		}
 	}
 
@@ -809,7 +730,7 @@ public class Main {
 		List<Tag<String>> regularExpressionTags = Arrays.asList(
 				ConfigTags.ProcessesToKillDuringTest,
 				ConfigTags.ClickFilter,
-				ConfigTags.SuspiciousTitles,
+				ConfigTags.SuspiciousTags,
 				ConfigTags.SuspiciousProcessOutput,
 				ConfigTags.ProcessLogs,
 				ConfigTags.WebConsoleErrorPattern,

--- a/testar/src/org/testar/monkey/Main.java
+++ b/testar/src/org/testar/monkey/Main.java
@@ -584,7 +584,7 @@ public class Main {
 					settings = Settings.fromFileCmd(defaults, file, argv);
 				}catch(IOException e) {
 					System.out.println("Error with command line properties. Examples:");
-					System.out.println("testar SUTConnectorValue=\"C:\\\\Windows\\\\System32\\\\notepad.exe\" Sequences=11 SequenceLength=12 SuspiciousTitle=.*aaa.*");
+					System.out.println("testar SUTConnectorValue=\"C:\\\\Windows\\\\System32\\\\notepad.exe\" Sequences=11 SequenceLength=12 SuspiciousTags=.*aaa.*");
 					System.out.println("SUTConnectorValue=\" \"\"C:\\\\Program Files\\\\Internet Explorer\\\\iexplore.exe\"\" \"\"https://www.google.es\"\" \"");
 				}
 				//SUTConnectorValue=" ""C:\\Program Files\\Internet Explorer\\iexplore.exe"" ""https://www.google.es"" "

--- a/testar/src/org/testar/monkey/Settings.java
+++ b/testar/src/org/testar/monkey/Settings.java
@@ -330,6 +330,36 @@ public class Settings extends TaggableBase implements Serializable {
 				, ConfigTags.SequenceLength.name() + " = "
 				, ""
 				, "#################################################################"
+				, "# SUT Protocol"
+				, "#"
+				, "# ProtocolClass: " + ConfigTags.ProtocolClass.getDescription()
+				, "# AlwaysCompile: " + ConfigTags.AlwaysCompile.getDescription()
+				, "#################################################################"
+				, ""
+				, ConfigTags.ProtocolClass.name() + " = "
+				, ConfigTags.AlwaysCompile.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Actionfilter"
+				, "#"
+				, "# Regular expression and Tags to apply them."
+				, "# More filters can be added in Spy mode, "
+				, "# these will be added to the protocol_filter.xml file."
+				, "#################################################################"
+				, ""
+				, ConfigTags.ClickFilter.name() + " = "
+				, ConfigTags.TagsToFilter.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Processfilter"
+				, "#"
+				, "# Regular expression. Kill the processes that your SUT can start up"
+				, "# but that you do not want to test."
+				, "#################################################################"
+				, ""
+				, ConfigTags.ProcessesToKillDuringTest.name() + " = "
+				, ""
+				, "#################################################################"
 				, "# Oracles based on suspicious tag values"
 				, "#"
 				, "# Regular expression and Tags to apply them"
@@ -366,35 +396,36 @@ public class Settings extends TaggableBase implements Serializable {
 				, ConfigTags.ProcessLogs.name() + " = "
 				, ""
 				, "#################################################################"
-				, "# Actionfilter"
+				, "# Time configurations"
 				, "#"
-				, "# Regular expression and Tags to apply them."
-				, "# More filters can be added in Spy mode, "
-				, "# these will be added to the protocol_filter.xml file."
+				, "# ActionDuration: " + ConfigTags.ActionDuration.getDescription()
+				, "# TimeToWaitAfterAction: " + ConfigTags.TimeToWaitAfterAction.getDescription()
+				, "# StartupTime: " + ConfigTags.StartupTime.getDescription()
+				, "# MaxTime: " + ConfigTags.MaxTime.getDescription()
 				, "#################################################################"
 				, ""
-				, ConfigTags.ClickFilter.name() + " = "
-				, ConfigTags.TagsToFilter.name() + " = "
-				, ""
-				, "#################################################################"
-				, "# Processfilter"
-				, "#"
-				, "# Regular expression. Kill the processes that your SUT can start up"
-				, "# but that you do not want to test."
-				, "#################################################################"
-				, ""
-				, ConfigTags.ProcessesToKillDuringTest.name() + " = "
-				, ""
-				, "#################################################################"
-				, "# Protocolclass"
-				, "#"
-				, "# Indicate the location of the protocol class for your specific SUT."
-				, "#################################################################"
-				, ""
-				, ConfigTags.ProtocolClass.name() + " = "
+				, ConfigTags.ActionDuration.name() + " = "
+				, ConfigTags.TimeToWaitAfterAction.name() + " = "
+				, ConfigTags.StartupTime.name() + " = "
+				, ConfigTags.MaxTime.name() + " = "
 				, ""
 				, "#################################################################"
 				, "# State model inference settings"
+				, "#"
+				, "# StateModelEnabled: " + ConfigTags.StateModelEnabled.getDescription()
+				, "# DataStore: " + ConfigTags.DataStore.getDescription()
+				, "# DataStoreType: " + ConfigTags.DataStoreType.getDescription()
+				, "# DataStoreServer: " + ConfigTags.DataStoreServer.getDescription()
+				, "# DataStoreDirectory: " + ConfigTags.DataStoreDirectory.getDescription()
+				, "# DataStoreDB: " + ConfigTags.DataStoreDB.getDescription()
+				, "# DataStoreUser: " + ConfigTags.DataStoreUser.getDescription()
+				, "# DataStorePassword: " + ConfigTags.DataStorePassword.getDescription()
+				, "# DataStoreMode: " + ConfigTags.DataStoreMode.getDescription()
+				, "# ApplicationName: " + ConfigTags.ApplicationName.getDescription()
+				, "# ApplicationVersion: " + ConfigTags.ApplicationVersion.getDescription()
+				, "# ActionSelectionAlgorithm: " + ConfigTags.ActionSelectionAlgorithm.getDescription()
+				, "# StateModelStoreWidgets: " + ConfigTags.StateModelStoreWidgets.getDescription()
+				, "# ResetDataStore: " + ConfigTags.ResetDataStore.getDescription()
 				, "#################################################################"
 				, ""
 				, ConfigTags.StateModelEnabled.name() + " = "
@@ -423,6 +454,14 @@ public class Settings extends TaggableBase implements Serializable {
 				, ""
 				, "#################################################################"
 				, "# WebDriver features"
+				, "#"
+				, "# ClickableClasses: " + ConfigTags.ClickableClasses.getDescription()
+				, "# TypeableClasses: " + ConfigTags.TypeableClasses.getDescription()
+				, "# DeniedExtensions: " + ConfigTags.DeniedExtensions.getDescription()
+				, "# DomainsAllowed: " + ConfigTags.DomainsAllowed.getDescription()
+				, "# FollowLinks: " + ConfigTags.FollowLinks.getDescription()
+				, "# BrowserFullScreen: " + ConfigTags.BrowserFullScreen.getDescription()
+				, "# SwitchNewTabs: " + ConfigTags.SwitchNewTabs.getDescription()
 				, "#################################################################"
 				, ""
 				, ConfigTags.ClickableClasses.name() + " = "
@@ -435,6 +474,11 @@ public class Settings extends TaggableBase implements Serializable {
 				, ""
 				, "#################################################################"
 				, "# WebDriver Browser Console Oracles"
+				, "#"
+				, "# WebConsoleErrorOracle: " + ConfigTags.WebConsoleErrorOracle.getDescription()
+				, "# WebConsoleErrorPattern: " + ConfigTags.WebConsoleErrorPattern.getDescription()
+				, "# WebConsoleWarningOracle: " + ConfigTags.WebConsoleWarningOracle.getDescription()
+				, "# WebConsoleWarningPattern: " + ConfigTags.WebConsoleWarningPattern.getDescription()
 				, "#################################################################"
 				, ""
 				, ConfigTags.WebConsoleErrorOracle.name() + " = "
@@ -480,25 +524,20 @@ public class Settings extends TaggableBase implements Serializable {
 		// Second, create a list of secondary configuration tags settings
 		// To add their descriptions to the file
 		List<Tag<?>> secondarySettingsList = new ArrayList<>();
-		secondarySettingsList.add(ConfigTags.ActionDuration);
-		secondarySettingsList.add(ConfigTags.TimeToWaitAfterAction);
-		secondarySettingsList.add(ConfigTags.StartupTime);
-		secondarySettingsList.add(ConfigTags.MaxTime);
-		secondarySettingsList.add(ConfigTags.FormFillingAction);
-		secondarySettingsList.add(ConfigTags.SUTProcesses);
 		secondarySettingsList.add(ConfigTags.ShowVisualSettingsDialogOnStartup);
 		secondarySettingsList.add(ConfigTags.ForceForeground);
+		secondarySettingsList.add(ConfigTags.VisualizeActions);
+		secondarySettingsList.add(ConfigTags.FormFillingAction);
+		secondarySettingsList.add(ConfigTags.SUTProcesses);
 		secondarySettingsList.add(ConfigTags.LogLevel);
 		secondarySettingsList.add(ConfigTags.OnlySaveFaultySequences);
 		secondarySettingsList.add(ConfigTags.ReplayRetryTime);
 		secondarySettingsList.add(ConfigTags.StopGenerationOnFault);
 		secondarySettingsList.add(ConfigTags.TimeToFreeze);
 		secondarySettingsList.add(ConfigTags.UseRecordedActionDurationAndWaitTimeDuringReplay);
-		secondarySettingsList.add(ConfigTags.VisualizeActions);
 		secondarySettingsList.add(ConfigTags.UseSystemActions);
 		secondarySettingsList.add(ConfigTags.PathToReplaySequence);
 		secondarySettingsList.add(ConfigTags.RefreshSpyCanvas);
-		secondarySettingsList.add(ConfigTags.AlwaysCompile);
 		secondarySettingsList.add(ConfigTags.FlashFeedback);
 		secondarySettingsList.add(ConfigTags.MaxReward);
 		secondarySettingsList.add(ConfigTags.Discount);

--- a/testar/src/org/testar/monkey/Settings.java
+++ b/testar/src/org/testar/monkey/Settings.java
@@ -504,6 +504,8 @@ public class Settings extends TaggableBase implements Serializable {
 		secondarySettingsList.add(ConfigTags.CreateWidgetInfoJsonFile);
 		secondarySettingsList.add(ConfigTags.MyClassPath);
 		secondarySettingsList.add(ConfigTags.ProtocolCompileDirectory);
+		secondarySettingsList.add(ConfigTags.OutputDir);
+		secondarySettingsList.add(ConfigTags.TempDir);
 		secondarySettingsList.add(ConfigTags.ReportingClass);
 
 		StringJoiner secondaryString = new StringJoiner(System.getProperty("line.separator"));

--- a/testar/src/org/testar/monkey/Settings.java
+++ b/testar/src/org/testar/monkey/Settings.java
@@ -1,32 +1,32 @@
 /***************************************************************************************************
-*
-* Copyright (c) 2013 - 2021 Universitat Politecnica de Valencia - www.upv.es
-* Copyright (c) 2018 - 2021 Open Universiteit - www.ou.nl
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice,
-* this list of conditions and the following disclaimer.
-* 2. Redistributions in binary form must reproduce the above copyright
-* notice, this list of conditions and the following disclaimer in the
-* documentation and/or other materials provided with the distribution.
-* 3. Neither the name of the copyright holder nor the names of its
-* contributors may be used to endorse or promote products derived from
-* this software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-* POSSIBILITY OF SUCH DAMAGE.
-*******************************************************************************************************/
+ *
+ * Copyright (c) 2013 - 2023 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2018 - 2023 Open Universiteit - www.ou.nl
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************************************/
 
 package org.testar.monkey;
 
@@ -57,7 +57,7 @@ public class Settings extends TaggableBase implements Serializable {
 	public static final String SUT_CONNECTOR_WEBDRIVER = "WEB_DRIVER";
 
 	private static String settingsPath;
-	
+
 	public static String getSettingsPath() {
 		return settingsPath;
 	}
@@ -65,7 +65,7 @@ public class Settings extends TaggableBase implements Serializable {
 	public static void setSettingsPath(String path) {
 		settingsPath = path;
 	}
-	
+
 	public static class ConfigParseException extends FruitException{
 		private static final long serialVersionUID = -245853379631399673L;
 		public ConfigParseException(String message) {
@@ -78,7 +78,7 @@ public class Settings extends TaggableBase implements Serializable {
 			StringBuilder sb = new StringBuilder();
 			String stringSeparator = getStringSeparator(tag);
 			List<?> l = (List<?>) value;
-			
+
 			int i = 0;
 			for(Object o : l){
 				if(i > 0)
@@ -91,7 +91,7 @@ public class Settings extends TaggableBase implements Serializable {
 			StringBuilder sb = new StringBuilder();
 			@SuppressWarnings("unchecked")
 			List<Pair<String, String>> l = (List<Pair<String, String>>) value;
-			
+
 			int i = 0;
 			for(Pair<String, String> p : l){
 				if(i > 0)
@@ -103,7 +103,7 @@ public class Settings extends TaggableBase implements Serializable {
 		}
 		return Util.toString(value);
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	public static <T> T parse(String stringValue, Tag<T> tag) throws ConfigParseException{
 		if(tag.type().equals(Double.class)){
@@ -155,8 +155,8 @@ public class Settings extends TaggableBase implements Serializable {
 		}
 		throw new ConfigParseException("");
 	}
-	
-	
+
+
 	public static Settings FromFile(String path) throws IOException{
 		return fromFile(new ArrayList<Pair<?, ?>>(), path);
 	}
@@ -182,16 +182,16 @@ public class Settings extends TaggableBase implements Serializable {
 		InputStreamReader isw = new InputStreamReader(fis, "UTF-8");
 		Reader in = new BufferedReader(isw);
 		props.load(in);
-		
+
 		for(String sett : argv) {
 			//Ignore sse value
 			if(sett.toString().contains("sse=")) continue;
-			
+
 			System.out.println(sett.toString());
 			StringReader sr = new StringReader(sett);
 			props.load(sr);
 		}
-		
+
 		in.close();			
 		if (isw != null) isw.close();
 		if (fis != null) fis.close();
@@ -218,9 +218,9 @@ public class Settings extends TaggableBase implements Serializable {
 
 		for(String key : props.stringPropertyNames()){
 			String value = props.getProperty(key);
-			
+
 			Tag<?> defaultTag = null;
-			
+
 			for(Pair<?, ?> pair : defaults){
 				Tag<?> tag = (Tag<?>)pair.left();
 				if(tag.name().equals(key)){
@@ -249,208 +249,16 @@ public class Settings extends TaggableBase implements Serializable {
 		}
 		return sb.toString();
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	/**
 	 * Make the default file Structure for the test.settings file
 	 */
-	public String toFileString() throws IOException{
-		StringBuilder sb = new StringBuilder();
-
+	public String toFileString() throws IOException {
+		// Create the default settings structure
+		StringBuilder sb = new StringBuilder(testSettingsStructure());
+		// Then add the settings values
 		try {
-			//test.setting default structure
-			sb.append("#################################################################\n"
-					+"# TESTAR mode\n"
-					+"#\n"
-					+"# Set the mode you want TESTAR to start in: Spy, Generate, Replay\n"
-					+"#################################################################\n"
-					+"\n"
-					+"Mode =" + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Connect to the System Under Test (SUT)\n"
-					+"#\n"
-					+"# Indicate how you want to connect to the SUT:\n"
-					+"#\n"
-					+"# SUTCONNECTOR = COMMAND_LINE, SUTConnectorValue property must be a command line that\n"
-					+"# starts the SUT.\n"
-					+"# It should work from a Command Prompt terminal window (e.g. java - jar SUTs/calc.jar ).\n"
-					+"# For web applications, follow the next format: web_browser_path SUT_URL.\n"
-					+"#\n"
-					+"# SUTCONNECTOR = SUT_WINDOW_TITLE, then SUTConnectorValue property must be the title displayed\n"
-					+"# in the SUT main window. The SUT must be manually started and closed.\n"
-					+"#\n"
-					+"# SUTCONNECTOR = SUT_PROCESS_NAME: SUTConnectorValue property must be the process name of the SUT.\n"
-					+"# The SUT must be manually started and closed.\n"
-					+"#################################################################\n"
-					+"SUTConnector = " + Util.lineSep()
-					+"SUTConnectorValue = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Java Swing applications & Access Bridge Enabled\n"
-					+"#\n"
-					+"# Activate the Java Access Bridge in your Windows System:\n"
-					+"#		(Control Panel / Ease of Access / Ease of Access Center / Make the computer easier to see)\n"
-					+"#\n"
-					+"# Enable the variable Access Bridge Enabled in TESTAR as true\n"
-					+"#################################################################\n"
-					+"\n"
-					+"AccessBridgeEnabled = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Sequences\n"
-					+"#\n"
-					+"# Number of sequences and the length of these sequences\n"
-					+"#################################################################\n"
-					+"\n"
-					+"Sequences = " + Util.lineSep()
-					+"SequenceLength = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Oracles based on suspicious titles\n"
-					+"#\n"
-					+"# Regular expression and Tags to apply them\n"
-					+"#################################################################\n"
-					+"\n"
-					+"SuspiciousTitles = " + Util.lineSep()
-					+"TagsForSuspiciousOracle = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Oracles based on Suspicious Outputs detected by Process Listeners\n"
-					+"#\n"
-					+"# Requires ProcessListenerEnabled\n"
-					+"# (Only available for desktop applications through COMMAND_LINE)\n"
-					+"#\n"
-					+"# Regular expression SuspiciousProcessOutput contains the specification\n"
-					+"# of what is considered to be suspicious output.\n"
-					+"#################################################################\n"
-					+"\n"
-					+"ProcessListenerEnabled = " + Util.lineSep()
-					+"SuspiciousProcessOutput = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Process Logs\n"
-					+"#\n"
-					+"# Required ProcessListenerEnabled\n"
-					+"# (Only available for desktop applications through COMMAND_LINE)\n"
-					+"#\n"
-					+"# Allow TESTAR to store execution logs coming from the processes.\n"
-					+"# You can use the regular expression ProcessLogs below to filter\n"
-					+"# the logs. Use .*.* if you want to store all the outputs of the \n"
-					+"# process.\n"
-					+"#################################################################\n"
-					+"\n"
-					+"ProcessLogs = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Actionfilter\n"
-					+"#\n"
-					+"# Regular expression and Tags to apply them.\n"
-					+"# More filters can be added in Spy mode,\n"
-					+"# these will be added to the protocol_filter.xml file.\n"
-					+"#################################################################\n"
-					+"\n"
-					+"ClickFilter = " + Util.lineSep()
-					+"TagsToFilter = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Processfilter\n"
-					+"#\n"
-					+"# Regular expression. Kill the processes that your SUT can start up\n"
-					+"# but that you do not want to test.\n"
-					+"#################################################################\n"
-					+"\n"
-					+"SUTProcesses = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Protocolclass\n"
-					+"#\n"
-					+"# Indicate the location of the protocol class for your specific SUT.\n"
-					+"#################################################################\n"
-					+"\n"
-					+"ProtocolClass = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# State model inference settings\n"
-					+"#################################################################\n"
-					+"StateModelEnabled = " + Util.lineSep()
-					+"DataStore = " + Util.lineSep()
-					+"DataStoreType = " + Util.lineSep()
-					+"DataStoreServer = " + Util.lineSep()
-					+"DataStoreDirectory = " + Util.lineSep()
-					+"DataStoreDB = " + Util.lineSep()
-					+"DataStoreUser = " + Util.lineSep()
-					+"DataStorePassword = " + Util.lineSep()
-					+"DataStoreMode = " + Util.lineSep()
-					+"ApplicationName = " + Util.lineSep()
-					+"ApplicationVersion = " + Util.lineSep()
-					+"ActionSelectionAlgorithm = " + Util.lineSep()
-					+"StateModelStoreWidgets = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# State identifier attributes\n"
-					+"#\n"
-					+"# Specify the widget attributes that you wish to use in constructing\n"
-					+"# the widget and state hash strings. Use a comma separated list.\n"
-					+"#################################################################\n"
-					+"AbstractStateAttributes = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# WebDriver features\n"
-					+"#################################################################\n"
-					+"\n"
-					+"ClickableClasses = " + Util.lineSep()
-					+"DeniedExtensions = " + Util.lineSep()
-					+"DomainsAllowed = " + Util.lineSep()
-					+"FollowLinks = " + Util.lineSep()
-					+"BrowserFullScreen = " + Util.lineSep()
-					+"SwitchNewTabs = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# WebDriver Browser Console Oracles\n"
-					+"#################################################################\n"
-					+"WebConsoleErrorOracle = " + Util.lineSep()
-					+"WebConsoleErrorPattern = " + Util.lineSep()
-					+"WebConsoleWarningOracle = " + Util.lineSep()
-					+"WebConsoleWarningPattern = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Override display scale\n"
-					+"#\n"
-					+"# Overrides the displayscale obtained from the system.\n"
-					+"# Can solve problems when the mouse clicks are not aligned with\n"
-					+"# the elements on the screen. This can easily be detected when\n"
-					+"# running the spy mode. For example hover over a text element and\n"
-					+"# the popup window should appear with information about the\n"
-					+"# element, if the popup window is not shown or when the mouse is\n"
-					+"# located somewhere else you can try to override the displayscale\n"
-					+"# Values should be provided as doubles (1.5).\n"
-					+"#################################################################\n"
-					+"\n"
-					+"OverrideWebDriverDisplayScale = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Settings (string) that can be used for user specified protocols\n"
-					+"#################################################################\n"
-					+"\n"
-					+"ProtocolSpecificSetting_1 = " + Util.lineSep()
-					+"ProtocolSpecificSetting_2 = " + Util.lineSep()
-					+"ProtocolSpecificSetting_3 = " + Util.lineSep()
-					+"ProtocolSpecificSetting_4 = " + Util.lineSep()
-					+"ProtocolSpecificSetting_5 = " + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Extended settings file\n"
-					+"#\n"
-					+"# Relative path to extended settings file.\n"
-					+"#################################################################\n"
-					+"ExtendedSettingsFile =" + Util.lineSep()
-					+"\n"
-					+"#################################################################\n"
-					+"# Other more advanced settings\n"
-					+"#################################################################\n");
-
-
 			for(Tag<?> t : tags()){
 				int ini = sb.indexOf(t.name()+" =");
 				int end = sb.indexOf(System.lineSeparator(), ini);
@@ -462,15 +270,267 @@ public class Settings extends TaggableBase implements Serializable {
 					sb.append(t.name()).append(" = ").append(escapeBackslash(print((Tag<Object>) t, get(t)))).append(Util.lineSep());
 				}
 			}
-			
+
 		} catch (NoSuchTagException e) {
-			System.out.println("Error trying to save current settings "+e);
+			System.out.println("Error trying to save current settings " + e);
 		}
 
 		return sb.toString();
 	}
-	
-	
+
+	private String testSettingsStructure() {
+		// First, create the main structure that contains specific format and descriptions
+		String mainString = String.join(System.getProperty("line.separator")
+				, "#################################################################"
+				, "# TESTAR mode"
+				, "#"
+				, "# Set the mode you want TESTAR to start in: Spy, Generate, Replay"
+				, "#################################################################"
+				, ""
+				, ConfigTags.Mode.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Connect to the System Under Test (SUT)"
+				, "#"
+				, "# Indicate how you want to connect to the SUT:"
+				, "#"
+				, "# SUTCONNECTOR = COMMAND_LINE, SUTConnectorValue property must be a command line that"
+				, "# starts the SUT."
+				, "# It should work from a Command Prompt terminal window (e.g. java - jar SUTs/calc.jar )."
+				, "# For web applications, follow the next format: web_browser_path SUT_URL."
+				, "#"
+				, "# SUTCONNECTOR = SUT_WINDOW_TITLE, then SUTConnectorValue property must be the title displayed"
+				, "# in the SUT main window. The SUT must be manually started and closed."
+				, "#"
+				, "# SUTCONNECTOR = SUT_PROCESS_NAME: SUTConnectorValue property must be the process name of the SUT."
+				, "# The SUT must be manually started and closed."
+				, "#################################################################"
+				, ""
+				, ConfigTags.SUTConnector.name() + " = "
+				, ConfigTags.SUTConnectorValue.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Java Swing applications & Access Bridge Enabled"
+				, "#"
+				, "# Activate the Java Access Bridge in your Windows System:"
+				, "#		(Control Panel / Ease of Access / Ease of Access Center / Make the computer easier to see)"
+				, "#"
+				, "# Enable the variable Access Bridge Enabled in TESTAR as true"
+				, "#################################################################"
+				, ""
+				, ConfigTags.AccessBridgeEnabled.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Sequences"
+				, "#"
+				, "# Number of sequences and the length of these sequences"
+				, "#################################################################"
+				, ""
+				, ConfigTags.Sequences.name() + " = "
+				, ConfigTags.SequenceLength.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Oracles based on suspicious tag values"
+				, "#"
+				, "# Regular expression and Tags to apply them"
+				, "#################################################################"
+				, ""
+				, ConfigTags.SuspiciousTags.name() + " = "
+				, ConfigTags.TagsForSuspiciousOracle.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Oracles based on Suspicious Outputs detected by Process Listeners"
+				, "#"
+				, "# Requires ProcessListenerEnabled"
+				, "# (Only available for desktop applications through COMMAND_LINE)"
+				, "#"
+				, "# Regular expression SuspiciousProcessOutput contains the specification"
+				, "# of what is considered to be suspicious output."
+				, "#################################################################"
+				, ""
+				, ConfigTags.ProcessListenerEnabled.name() + " = "
+				, ConfigTags.SuspiciousProcessOutput.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Process Logs"
+				, "#"
+				, "# Required ProcessListenerEnabled"
+				, "# (Only available for desktop applications through COMMAND_LINE)"
+				, "#"
+				, "# Allow TESTAR to store execution logs coming from the processes."
+				, "# You can use the regular expression ProcessLogs below to filter"
+				, "# the logs. Use .*.* if you want to store all the outputs of the "
+				, "# process."
+				, "#################################################################"
+				, ""
+				, ConfigTags.ProcessLogs.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Actionfilter"
+				, "#"
+				, "# Regular expression and Tags to apply them."
+				, "# More filters can be added in Spy mode, "
+				, "# these will be added to the protocol_filter.xml file."
+				, "#################################################################"
+				, ""
+				, ConfigTags.ClickFilter.name() + " = "
+				, ConfigTags.TagsToFilter.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Processfilter"
+				, "#"
+				, "# Regular expression. Kill the processes that your SUT can start up"
+				, "# but that you do not want to test."
+				, "#################################################################"
+				, ""
+				, ConfigTags.ProcessesToKillDuringTest.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Protocolclass"
+				, "#"
+				, "# Indicate the location of the protocol class for your specific SUT."
+				, "#################################################################"
+				, ""
+				, ConfigTags.ProtocolClass.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# State model inference settings"
+				, "#################################################################"
+				, ""
+				, ConfigTags.StateModelEnabled.name() + " = "
+				, ConfigTags.DataStore.name() + " = "
+				, ConfigTags.DataStoreType.name() + " = "
+				, ConfigTags.DataStoreServer.name() + " = "
+				, ConfigTags.DataStoreDirectory.name() + " = "
+				, ConfigTags.DataStoreDB.name() + " = "
+				, ConfigTags.DataStoreUser.name() + " = "
+				, ConfigTags.DataStorePassword.name() + " = "
+				, ConfigTags.DataStoreMode.name() + " = "
+				, ConfigTags.ApplicationName.name() + " = "
+				, ConfigTags.ApplicationVersion.name() + " = "
+				, ConfigTags.ActionSelectionAlgorithm.name() + " = "
+				, ConfigTags.StateModelStoreWidgets.name() + " = "
+				, ConfigTags.ResetDataStore.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# State identifier attributes"
+				, "#"
+				, "# Specify the widget attributes that you wish to use in constructing"
+				, "# the widget and state hash strings. Use a comma separated list."
+				, "#################################################################"
+				, ""
+				, ConfigTags.AbstractStateAttributes.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# WebDriver features"
+				, "#################################################################"
+				, ""
+				, ConfigTags.ClickableClasses.name() + " = "
+				, ConfigTags.DeniedExtensions.name() + " = "
+				, ConfigTags.DomainsAllowed.name() + " = "
+				, ConfigTags.FollowLinks.name() + " = "
+				, ConfigTags.BrowserFullScreen.name() + " = "
+				, ConfigTags.SwitchNewTabs.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# WebDriver Browser Console Oracles"
+				, "#################################################################"
+				, ""
+				, ConfigTags.WebConsoleErrorOracle.name() + " = "
+				, ConfigTags.WebConsoleErrorPattern.name() + " = "
+				, ConfigTags.WebConsoleWarningOracle.name() + " = "
+				, ConfigTags.WebConsoleWarningPattern.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Override display scale"
+				, "#"
+				, "# Overrides the displayscale obtained from the system."
+				, "# Can solve problems when the mouse clicks are not aligned with"
+				, "# the elements on the screen. This can easily be detected when"
+				, "# running the spy mode. For example hover over a text element and"
+				, "# the popup window should appear with information about the"
+				, "# element, if the popup window is not shown or when the mouse is"
+				, "# located somewhere else you can try to override the displayscale"
+				, "# Values should be provided as doubles (1.5)."
+				, "#################################################################"
+				, ""
+				, ConfigTags.OverrideWebDriverDisplayScale.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Settings (string) that can be used for user specified protocols"
+				, "#################################################################"
+				, ""
+				, ConfigTags.ProtocolSpecificSetting_1.name() + " = "
+				, ConfigTags.ProtocolSpecificSetting_2.name() + " = "
+				, ConfigTags.ProtocolSpecificSetting_3.name() + " = "
+				, ConfigTags.ProtocolSpecificSetting_4.name() + " = "
+				, ConfigTags.ProtocolSpecificSetting_5.name() + " = "
+				, ""
+				, "#################################################################"
+				, "# Extended settings file"
+				, "#"
+				, "# Relative path to extended settings file."
+				, "#################################################################"
+				, ""
+				, ConfigTags.ExtendedSettingsFile.name() + " = "
+				, ""
+				);
+
+		// Second, create a list of secondary configuration tags settings
+		// To add their descriptions to the file
+		List<Tag<?>> secondarySettingsList = new ArrayList<>();
+		secondarySettingsList.add(ConfigTags.ActionDuration);
+		secondarySettingsList.add(ConfigTags.TimeToWaitAfterAction);
+		secondarySettingsList.add(ConfigTags.StartupTime);
+		secondarySettingsList.add(ConfigTags.MaxTime);
+		secondarySettingsList.add(ConfigTags.FormFillingAction);
+		secondarySettingsList.add(ConfigTags.SUTProcesses);
+		secondarySettingsList.add(ConfigTags.ShowVisualSettingsDialogOnStartup);
+		secondarySettingsList.add(ConfigTags.ForceForeground);
+		secondarySettingsList.add(ConfigTags.LogLevel);
+		secondarySettingsList.add(ConfigTags.OnlySaveFaultySequences);
+		secondarySettingsList.add(ConfigTags.ReplayRetryTime);
+		secondarySettingsList.add(ConfigTags.StopGenerationOnFault);
+		secondarySettingsList.add(ConfigTags.TimeToFreeze);
+		secondarySettingsList.add(ConfigTags.UseRecordedActionDurationAndWaitTimeDuringReplay);
+		secondarySettingsList.add(ConfigTags.VisualizeActions);
+		secondarySettingsList.add(ConfigTags.UseSystemActions);
+		secondarySettingsList.add(ConfigTags.PathToReplaySequence);
+		secondarySettingsList.add(ConfigTags.RefreshSpyCanvas);
+		secondarySettingsList.add(ConfigTags.AlwaysCompile);
+		secondarySettingsList.add(ConfigTags.FlashFeedback);
+		secondarySettingsList.add(ConfigTags.MaxReward);
+		secondarySettingsList.add(ConfigTags.Discount);
+		secondarySettingsList.add(ConfigTags.CreateWidgetInfoJsonFile);
+		secondarySettingsList.add(ConfigTags.MyClassPath);
+		secondarySettingsList.add(ConfigTags.ProtocolCompileDirectory);
+		secondarySettingsList.add(ConfigTags.ReportingClass);
+
+		StringJoiner secondaryString = new StringJoiner(System.getProperty("line.separator"));
+		for(Tag<?> set : secondarySettingsList) {
+			// Make sure it contains a description
+			if(!set.getDescription().isEmpty()) {
+				secondaryString.add("#################################################################");
+				secondaryString.add("# " + set.getDescription());
+				secondaryString.add("#################################################################");
+				secondaryString.add("");
+				secondaryString.add(set.name() + " = ");
+				secondaryString.add("");
+			}
+		}
+
+		// Finally, create the structure for other settings
+		StringJoiner otherString = new StringJoiner(System.getProperty("line.separator"));
+		otherString.add("#################################################################");
+		otherString.add("# Other settings");
+		otherString.add("#################################################################");
+		otherString.add("");
+
+		return mainString
+				.concat(System.getProperty("line.separator") + secondaryString.toString())
+				.concat(System.getProperty("line.separator") + otherString.toString());
+	}
+
 	private String escapeBackslash(String string){ return string.replace("\\", "\\\\");	}
 
 	/**
@@ -479,22 +539,22 @@ public class Settings extends TaggableBase implements Serializable {
 	private void verifySettings() {
 		// verify the concrete and abstract state settings
 		// the values provided should be valid state management tags
-        Set<String> allowedStateAttributes = StateManagementTags.getAllTags().stream().map(StateManagementTags::getSettingsStringFromTag).collect(Collectors.toSet());
+		Set<String> allowedStateAttributes = StateManagementTags.getAllTags().stream().map(StateManagementTags::getSettingsStringFromTag).collect(Collectors.toSet());
 
 		// add only the state management tags that are available
 		Set<String> stateSet = new HashSet<>();
-        try {
-            List<String> abstractStateAttributes = get(ConfigTags.AbstractStateAttributes);
-            for (String abstractStateAttribute : abstractStateAttributes) {
-                if (allowedStateAttributes.contains(abstractStateAttribute)) {
-                    stateSet.add(abstractStateAttribute);
-                }
-            }
-            set(ConfigTags.AbstractStateAttributes, new ArrayList<>(stateSet));
-        }
-        catch (NoSuchTagException ex) {
-            // no need to do anything, nothing to verify
-        }
+		try {
+			List<String> abstractStateAttributes = get(ConfigTags.AbstractStateAttributes);
+			for (String abstractStateAttribute : abstractStateAttributes) {
+				if (allowedStateAttributes.contains(abstractStateAttribute)) {
+					stateSet.add(abstractStateAttribute);
+				}
+			}
+			set(ConfigTags.AbstractStateAttributes, new ArrayList<>(stateSet));
+		}
+		catch (NoSuchTagException ex) {
+			// no need to do anything, nothing to verify
+		}
 	}
 
 	private static String getStringSeparator(Tag<?> tag) {

--- a/testar/src/org/testar/protocols/WebdriverProtocol.java
+++ b/testar/src/org/testar/protocols/WebdriverProtocol.java
@@ -325,7 +325,7 @@ public class WebdriverProtocol extends GenericUtilsProtocol {
     				String consoleErrorMsg = logEntry.getMessage();
     				Matcher matcherError = errorPattern.matcher(consoleErrorMsg);
     				if(matcherError.matches()) {
-    					webConsoleVerdict = new Verdict(Verdict.SEVERITY_SUSPICIOUS_TITLE, "Web Browser Console Error: " + consoleErrorMsg);
+    					webConsoleVerdict = new Verdict(Verdict.SEVERITY_SUSPICIOUS_TAG, "Web Browser Console Error: " + consoleErrorMsg);
     				}
     			}
     		}
@@ -346,7 +346,7 @@ public class WebdriverProtocol extends GenericUtilsProtocol {
     				String consoleWarningMsg = logEntry.getMessage();
     				Matcher matcherWarning = warningPattern.matcher(consoleWarningMsg);
     				if(matcherWarning.matches()) {
-    					webConsoleVerdict = new Verdict(Verdict.SEVERITY_SUSPICIOUS_TITLE, "Web Browser Console Warning: " + consoleWarningMsg);
+    					webConsoleVerdict = new Verdict(Verdict.SEVERITY_SUSPICIOUS_TAG, "Web Browser Console Warning: " + consoleWarningMsg);
     				}
     			}
     		}

--- a/testar/src/org/testar/settingsdialog/SettingsDialog.java
+++ b/testar/src/org/testar/settingsdialog/SettingsDialog.java
@@ -177,11 +177,11 @@ public class SettingsDialog extends JFrame implements Observer {
       throw new IllegalStateException("Your ClickFilter is not a valid regular expression!");
     }
 
-    userInputPattern = settings.get(ConfigTags.SuspiciousTitles);
+    userInputPattern = settings.get(ConfigTags.SuspiciousTags);
     try {
       Pattern.compile(userInputPattern);
     } catch (PatternSyntaxException exception) {
-      throw new IllegalStateException("Your Oracle SuspiciousTitles is not a valid regular expression!");
+      throw new IllegalStateException("Your Oracle SuspiciousTags is not a valid regular expression!");
     }
 
     userInputPattern = settings.get(ConfigTags.SuspiciousProcessOutput);

--- a/testar/src/org/testar/settingsdialog/SettingsDialog.java
+++ b/testar/src/org/testar/settingsdialog/SettingsDialog.java
@@ -261,7 +261,7 @@ public class SettingsDialog extends JFrame implements Observer {
     settingPanels.put(FILTER_TAB_INDEX, new Pair<>("Filters", new FilterPanel()));
     settingPanels.put(ORACLES_TAB_INDEX, new Pair<>("Oracles", new OraclePanel()));
     settingPanels.put(TIMES_TAB_INDEX, new Pair<>("Time Settings", new TimingPanel()));
-    settingPanels.put(MISC_TAB_INDEX, new Pair<>("Misc", new MiscPanel()));
+    //settingPanels.put(MISC_TAB_INDEX, new Pair<>("Misc", new MiscPanel())); // TODO: Misc panel is disabled temporally from the GUI
     settingPanels.put(MODEL_TAB_INDEX, new Pair<>("State Model", modelPanel = StateModelPanel.createStateModelPanel()));
 
     settingPanels.forEach((k,v) -> jTabsPane.add(v.left(),v.right()));

--- a/testar/src/org/testar/settingsdialog/dialog/OraclePanel.java
+++ b/testar/src/org/testar/settingsdialog/dialog/OraclePanel.java
@@ -47,18 +47,18 @@ public class OraclePanel extends SettingsPanel {
 
     private static final long serialVersionUID = -8633257917450402330L;
 
-    private JLabel suspiciousTitleLabel = new JLabel("Suspicious Titles based on Tags values (regular expression)");
-    private JLabel suspiciousTitleTagsLabel = new JLabel("Tags to apply the Suspicious Titles (semicolon to customize multiple Tags)");
-    private JLabel suspiciousProcessLabel = new JLabel("Suspicious Process Output (regular expression)");
+    private JLabel suspiciousTagsRegexLabel = new JLabel("Suspicious Tags values (regular expression)");
+    private JLabel applySuspiciousTagsLabel = new JLabel("Tags to apply the Suspicious Tags values (semicolon to customize multiple Tags)");
+    private JLabel suspiciousProcessRegexLabel = new JLabel("Suspicious Process Output (regular expression)");
     private JLabel freezeTimeLabel = new JLabel("Freeze Time:");
     private JLabel secondsLabel = new JLabel("seconds");
 
-    private JTextArea txtSuspTitles = new JTextArea();
-    private JTextArea txtTagsForSuspTitles = new JTextArea();
-    private JTextArea txtProcTitles = new JTextArea();
+    private JTextArea txtSuspTagsRegex = new JTextArea();
+    private JTextArea txtApplySuspTags = new JTextArea();
+    private JTextArea txtSuspProccesRegex = new JTextArea();
 
-    private RegexButton regexButtonSuspTitle = new RegexButton(txtSuspTitles);
-    private RegexButton regexButtonProcTitle = new RegexButton(txtProcTitles);
+    private RegexButton regexButtonSuspTags = new RegexButton(txtSuspTagsRegex);
+    private RegexButton regexButtonSuspProcces = new RegexButton(txtSuspProccesRegex);
 
     private JCheckBox processCheckBox;
     private JSpinner spnFreezeTime;
@@ -73,46 +73,46 @@ public class OraclePanel extends SettingsPanel {
     public OraclePanel() {
         setLayout(null);
 
-        suspiciousTitleLabel.setBounds(10, 5, 450, 27);
-        suspiciousTitleLabel.setToolTipText(ToolTipTexts.suspiciousTitlesTTT);
-        add(suspiciousTitleLabel);
+        suspiciousTagsRegexLabel.setBounds(10, 5, 450, 27);
+        suspiciousTagsRegexLabel.setToolTipText(ToolTipTexts.suspiciousTagsTTT);
+        add(suspiciousTagsRegexLabel);
 
-        regexButtonSuspTitle.setBounds(500, 5, 110, 27);
-        add(regexButtonSuspTitle);
+        regexButtonSuspTags.setBounds(500, 5, 110, 27);
+        add(regexButtonSuspTags);
 
-        txtSuspTitles.setLineWrap(true);
-        JScrollPane suspTitlePane = new JScrollPane(txtSuspTitles);
-        suspTitlePane.setBounds(10, 35, 600, 100);
-        suspTitlePane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
-        suspTitlePane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        add(suspTitlePane);
+        txtSuspTagsRegex.setLineWrap(true);
+        JScrollPane suspTagsRegexPane = new JScrollPane(txtSuspTagsRegex);
+        suspTagsRegexPane.setBounds(10, 35, 600, 100);
+        suspTagsRegexPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        suspTagsRegexPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        add(suspTagsRegexPane);
 
-        suspiciousTitleTagsLabel.setBounds(10, 130, 600, 27);
-        add(suspiciousTitleTagsLabel);
+        applySuspiciousTagsLabel.setBounds(10, 130, 600, 27);
+        add(applySuspiciousTagsLabel);
 
-        txtTagsForSuspTitles.setLineWrap(true);
-        JScrollPane tagsForSuspTitlesPane = new JScrollPane(txtTagsForSuspTitles);
-        tagsForSuspTitlesPane.setBounds(10, 160, 600, 50);
-        tagsForSuspTitlesPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
-        tagsForSuspTitlesPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        add(tagsForSuspTitlesPane);
+        txtApplySuspTags.setLineWrap(true);
+        JScrollPane tagsApplySuspTagsPane = new JScrollPane(txtApplySuspTags);
+        tagsApplySuspTagsPane.setBounds(10, 160, 600, 50);
+        tagsApplySuspTagsPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        tagsApplySuspTagsPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        add(tagsApplySuspTagsPane);
 
-        suspiciousProcessLabel.setBounds(10, 220, 280, 27);
-        add(suspiciousProcessLabel);
+        suspiciousProcessRegexLabel.setBounds(10, 220, 280, 27);
+        add(suspiciousProcessRegexLabel);
 
         processCheckBox = new JCheckBox("Enable Process Listener");
         processCheckBox.setBounds(300, 220, 200, 27);
         add(processCheckBox);
         
-        regexButtonProcTitle.setBounds(500, 220, 110, 27);
-        add(regexButtonProcTitle);
+        regexButtonSuspProcces.setBounds(500, 220, 110, 27);
+        add(regexButtonSuspProcces);
 
-        txtProcTitles.setLineWrap(true);
-        JScrollPane suspiciousProcessPane = new JScrollPane(txtProcTitles);
-        suspiciousProcessPane.setBounds(10, 250, 600, 50);
-        suspiciousProcessPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
-        suspiciousProcessPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        add(suspiciousProcessPane);
+        txtSuspProccesRegex.setLineWrap(true);
+        JScrollPane suspProcessRegexPane = new JScrollPane(txtSuspProccesRegex);
+        suspProcessRegexPane.setBounds(10, 250, 600, 50);
+        suspProcessRegexPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        suspProcessRegexPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        add(suspProcessRegexPane);
 
         enableWebConsoleErrorOracle = new JCheckBox("Enable Web Console Error Oracle");
         enableWebConsoleErrorOracle.setBounds(10, 300, 300, 27);
@@ -146,10 +146,10 @@ public class OraclePanel extends SettingsPanel {
      */
     @Override
     public void populateFrom(final Settings settings) {
-        txtSuspTitles.setText(settings.get(ConfigTags.SuspiciousTags));
-        txtTagsForSuspTitles.setText(StringUtils.join(settings.get(ConfigTags.TagsForSuspiciousOracle), ";"));
+    	txtSuspTagsRegex.setText(settings.get(ConfigTags.SuspiciousTags));
+        txtApplySuspTags.setText(StringUtils.join(settings.get(ConfigTags.TagsForSuspiciousOracle), ";"));
         processCheckBox.setSelected(settings.get(ConfigTags.ProcessListenerEnabled));
-        txtProcTitles.setText(settings.get(ConfigTags.SuspiciousProcessOutput));
+        txtSuspProccesRegex.setText(settings.get(ConfigTags.SuspiciousProcessOutput));
         spnFreezeTime.setValue(settings.get(ConfigTags.TimeToFreeze));
         // Web Browser Console Oracles elements
         enableWebConsoleErrorOracle.setSelected(settings.get(ConfigTags.WebConsoleErrorOracle));
@@ -168,10 +168,10 @@ public class OraclePanel extends SettingsPanel {
      */
     @Override
     public void extractInformation(final Settings settings) {
-        settings.set(ConfigTags.SuspiciousTags, txtSuspTitles.getText());
-        settings.set(ConfigTags.TagsForSuspiciousOracle, Arrays.asList(txtTagsForSuspTitles.getText().split(";")));
+        settings.set(ConfigTags.SuspiciousTags, txtSuspTagsRegex.getText());
+        settings.set(ConfigTags.TagsForSuspiciousOracle, Arrays.asList(txtApplySuspTags.getText().split(";")));
         settings.set(ConfigTags.ProcessListenerEnabled, processCheckBox.isSelected());
-        settings.set(ConfigTags.SuspiciousProcessOutput, txtProcTitles.getText());
+        settings.set(ConfigTags.SuspiciousProcessOutput, txtSuspProccesRegex.getText());
         settings.set(ConfigTags.TimeToFreeze, (Double) spnFreezeTime.getValue());
         // Web Browser Console Oracles elements
         settings.set(ConfigTags.WebConsoleErrorOracle, enableWebConsoleErrorOracle.isSelected());

--- a/testar/src/org/testar/settingsdialog/dialog/OraclePanel.java
+++ b/testar/src/org/testar/settingsdialog/dialog/OraclePanel.java
@@ -146,7 +146,7 @@ public class OraclePanel extends SettingsPanel {
      */
     @Override
     public void populateFrom(final Settings settings) {
-        txtSuspTitles.setText(settings.get(ConfigTags.SuspiciousTitles));
+        txtSuspTitles.setText(settings.get(ConfigTags.SuspiciousTags));
         txtTagsForSuspTitles.setText(StringUtils.join(settings.get(ConfigTags.TagsForSuspiciousOracle), ";"));
         processCheckBox.setSelected(settings.get(ConfigTags.ProcessListenerEnabled));
         txtProcTitles.setText(settings.get(ConfigTags.SuspiciousProcessOutput));
@@ -168,7 +168,7 @@ public class OraclePanel extends SettingsPanel {
      */
     @Override
     public void extractInformation(final Settings settings) {
-        settings.set(ConfigTags.SuspiciousTitles, txtSuspTitles.getText());
+        settings.set(ConfigTags.SuspiciousTags, txtSuspTitles.getText());
         settings.set(ConfigTags.TagsForSuspiciousOracle, Arrays.asList(txtTagsForSuspTitles.getText().split(";")));
         settings.set(ConfigTags.ProcessListenerEnabled, processCheckBox.isSelected());
         settings.set(ConfigTags.SuspiciousProcessOutput, txtProcTitles.getText());

--- a/testar/src/org/testar/settingsdialog/dialog/ToolTipTexts.java
+++ b/testar/src/org/testar/settingsdialog/dialog/ToolTipTexts.java
@@ -105,7 +105,7 @@ public class ToolTipTexts {
   public static String label1TTT = "<html>\nClick-filter:<br>\n" +
       "Certain actions that TESTARs wants to execute might be dangerous or<br>\n" +
       "undesirable, such as printing out documents, creating, moving or deleting files.<br>\n" +
-      "TESTAR will not execute clicks on any widget whose title matches the given regular expression.<br>\n" +
+      "TESTAR will not execute clicks on any widget whose tag matches the given regular expression.<br>\n" +
       "To see whether or not your expression works, simply start TESTAR in Spy-Mode, which will<br>\n" +
       "visualize the detected actions.\n</html>";
   public static String label2TTT = "<html>\nProcesses to kill:<br>\n" +
@@ -114,10 +114,10 @@ public class ToolTipTexts {
       "TESTAR will kill any process whose name matches the given regular expression.\n</html>";
 
   // TTTs for the oracle panel
-  public static String suspiciousTitlesTTT =
+  public static String suspiciousTagsTTT =
       "<html>\nThis is a very simple oracle in the form of a regular expression, " +
-          "which is applied to each<br>widget's Title property. " +
-          "If TESTAR finds a widget on the screen, whose title matches the given<br>\n" +
+          "which is applied to each<br>widget's Tags property. " +
+          "If TESTAR finds a widget on the screen, whose Tag value matches the given<br>\n" +
           "expression, it will consider the current sequence to be erroneous.\n</html>";
   public static String enableVisualValidationTTT = "Use visual validation to validate the text labels";
 

--- a/testar/test/org/testar/monkey/TestRegularExpressionSettings.java
+++ b/testar/test/org/testar/monkey/TestRegularExpressionSettings.java
@@ -72,7 +72,7 @@ public class TestRegularExpressionSettings {
 	private List<Tag<String>> regularExpressionTags = Arrays.asList(
 			ConfigTags.ProcessesToKillDuringTest,
 			ConfigTags.ClickFilter,
-			ConfigTags.SuspiciousTitles,
+			ConfigTags.SuspiciousTags,
 			ConfigTags.SuspiciousProcessOutput,
 			ConfigTags.ProcessLogs,
 			ConfigTags.WebConsoleErrorPattern,

--- a/testar/workflow.gradle
+++ b/testar/workflow.gradle
@@ -79,7 +79,7 @@ task runTestDesktopGenericCommandLineSuspiciousTitle(type: Exec, dependsOn:'inst
     group = 'test_testar_workflow'
     description ='runTestDesktopGenericCommandLineSuspiciousTitle'
     workingDir 'target/install/testar/bin'
-    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_and_suspicious" TagsForSuspiciousOracle="NotExist;UIAAutomationId" SuspiciousTitles=".*MenuBar.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2 OnlySaveFaultySequences=true'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_and_suspicious" TagsForSuspiciousOracle="NotExist;UIAAutomationId" SuspiciousTags=".*MenuBar.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2 OnlySaveFaultySequences=true'
     doLast {
         String output = standardOutput.toString()
 
@@ -102,7 +102,7 @@ task runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle(type: Exec, d
     group = 'test_testar_workflow'
     description ='runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle'
     workingDir 'target/install/testar/bin'
-    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_settings_filter_and_suspicious" TagsToFilter="NotExist;Desc" ClickFilter=".*[sS]ystem.*|.*[cC]lose.*|.*[mM]inimize.*|.*[mM]aximize.*|Text Editor|File|Edit|View|Help|Word Wrap" SuspiciousTitles=".*[sS]cript.*" TimeToWaitAfterAction=2.0 ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_settings_filter_and_suspicious" TagsToFilter="NotExist;Desc" ClickFilter=".*[sS]ystem.*|.*[cC]lose.*|.*[mM]inimize.*|.*[mM]aximize.*|Text Editor|File|Edit|View|Help|Word Wrap" SuspiciousTags=".*[sS]cript.*" TimeToWaitAfterAction=2.0 ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
     doLast {
         String output = standardOutput.toString()
 
@@ -132,7 +132,7 @@ task runTestDesktopGenericProcessNameSuspiciousTitle(type: Exec, dependsOn:['ins
     group = 'test_testar_workflow'
     description ='runTestDesktopGenericProcessNameSuspiciousTitle'
     workingDir 'target/install/testar/bin'
-    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_process_and_suspicious" SuspiciousTitles=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=SUT_PROCESS_NAME SUTConnectorValue="notepad.exe" Sequences=1 SequenceLength=2'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_process_and_suspicious" SuspiciousTags=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=SUT_PROCESS_NAME SUTConnectorValue="notepad.exe" Sequences=1 SequenceLength=2'
     doLast {
         String output = standardOutput.toString()
 
@@ -157,7 +157,7 @@ task runTestDesktopGenericTitleNameSuspiciousTitle(type: Exec, dependsOn:['insta
     group = 'test_testar_workflow'
     description ='runTestDesktopGenericTitleNameSuspiciousTitle'
     workingDir 'target/install/testar/bin'
-    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_title_and_suspicious" SuspiciousTitles=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=SUT_WINDOW_TITLE SUTConnectorValue="Notepad" Sequences=1 SequenceLength=2'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_title_and_suspicious" SuspiciousTags=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=SUT_WINDOW_TITLE SUTConnectorValue="Notepad" Sequences=1 SequenceLength=2'
     doLast {
         String output = standardOutput.toString()
 
@@ -288,7 +288,7 @@ task runTestWebdriverSuspiciousTitle(type: Exec) {
     group = 'test_testar_workflow'
     description ='runTestWebdriverSuspiciousTitle'
     workingDir 'target/install/testar/bin'
-    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_webdriver_generic AlwaysCompile=true ApplicationName="webdriver_and_suspicious" TagsForSuspiciousOracle="NotExist;ValuePattern" SuspiciousTitles=".*[oO]nderwijs.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate Sequences=1 SequenceLength=2'
+    commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_webdriver_generic AlwaysCompile=true ApplicationName="webdriver_and_suspicious" TagsForSuspiciousOracle="NotExist;ValuePattern" SuspiciousTags=".*[oO]nderwijs.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate Sequences=1 SequenceLength=2'
     doLast {
         String output = standardOutput.toString()
 

--- a/testar/workflow.gradle
+++ b/testar/workflow.gradle
@@ -71,13 +71,13 @@ task runTestDesktopGenericMultiTags(type: Exec, dependsOn:'installDist') {
 
 // Default COMMAND_LINE execution to run Notepad
 // Test TagsForSuspiciousOracle feature using the UIATags.UIAAutomationId
-// Force TESTAR to find a Suspicious Title (MenuBar widget)
+// Force TESTAR to find a Suspicious Tag (MenuBar widget)
 // And verify it reading output command line
-task runTestDesktopGenericCommandLineSuspiciousTitle(type: Exec, dependsOn:'installDist') {
+task runTestDesktopGenericCommandLineSuspiciousTag(type: Exec, dependsOn:'installDist') {
 	// Read command line output
     standardOutput = new ByteArrayOutputStream()
     group = 'test_testar_workflow'
-    description ='runTestDesktopGenericCommandLineSuspiciousTitle'
+    description ='runTestDesktopGenericCommandLineSuspiciousTag'
     workingDir 'target/install/testar/bin'
     commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_and_suspicious" TagsForSuspiciousOracle="NotExist;UIAAutomationId" SuspiciousTags=".*MenuBar.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2 OnlySaveFaultySequences=true'
     doLast {
@@ -85,30 +85,30 @@ task runTestDesktopGenericCommandLineSuspiciousTitle(type: Exec, dependsOn:'inst
 
 		// Verify MenuBar UIAAutomationId has been detected
         if(output.readLines().any{line->line.contains("Discovered suspicious widget 'UIAAutomationId' : 'MenuBar")}) {
-            println "\n${output} \nTESTAR has successfully detected MenuBar Suspicious Title using TagsForSuspiciousOracle UIAAutomationId! "
+            println "\n${output} \nTESTAR has successfully detected MenuBar Suspicious Tag using TagsForSuspiciousOracle UIAAutomationId! "
         } else {
-            throw new GradleException("\n${output} \nERROR: TESTAR didnt detect MenuBar Suspicious Title using TagsForSuspiciousOracle UIAAutomationId")
+            throw new GradleException("\n${output} \nERROR: TESTAR didnt detect MenuBar Suspicious Tag using TagsForSuspiciousOracle UIAAutomationId")
         }
     }
 }
 
 // Default COMMAND_LINE execution to run Notepad
 // Test TagsToFilter feature using the Tag.Desc
-// Then force TESTAR to navigate and find a Suspicious Title Error (Script text)
+// Then force TESTAR to navigate and find a Suspicious Tag Title Error (Script text)
 // And verify it reading output command line
-task runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle(type: Exec, dependsOn:'installDist') {
+task runTestDesktopGenericCommandLineSettingsFilterSuspiciousTag(type: Exec, dependsOn:'installDist') {
 	// Read command line output
     standardOutput = new ByteArrayOutputStream()
     group = 'test_testar_workflow'
-    description ='runTestDesktopGenericCommandLineSettingsFilterSuspiciousTitle'
+    description ='runTestDesktopGenericCommandLineSettingsFilterSuspiciousTag'
     workingDir 'target/install/testar/bin'
     commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_command_settings_filter_and_suspicious" TagsToFilter="NotExist;Desc" ClickFilter=".*[sS]ystem.*|.*[cC]lose.*|.*[mM]inimize.*|.*[mM]aximize.*|Text Editor|File|Edit|View|Help|Word Wrap" SuspiciousTags=".*[sS]cript.*" TimeToWaitAfterAction=2.0 ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=COMMAND_LINE SUTConnectorValue="C:\\\\Windows\\\\System32\\\\notepad.exe" Sequences=1 SequenceLength=2'
     doLast {
         String output = standardOutput.toString()
 
-		// Verify Script title has been detected
+		// Verify Script tag has been detected
         if(output.readLines().any{line->line.contains("Discovered suspicious widget 'Title' : 'Script")}) {
-            println "\n${output} \nTESTAR has successfully filtered using TagsToFilter Desc and detected Script Suspicious Title! "
+            println "\n${output} \nTESTAR has successfully filtered using TagsToFilter Desc and detected Script Suspicious Tag! "
         } else {
             throw new GradleException("\n${output} \nERROR: TESTAR didnt filter using TagsToFilter Desc")
         }
@@ -125,12 +125,12 @@ task runNotepad {
 }
 
 // Verify that TESTAR correctly connects using process name
-// To be sure, connect to process and detect Format suspicious title
-task runTestDesktopGenericProcessNameSuspiciousTitle(type: Exec, dependsOn:['installDist','runNotepad']) {
+// To be sure, connect to process and detect Format suspicious tag Title
+task runTestDesktopGenericProcessNameSuspiciousTag(type: Exec, dependsOn:['installDist','runNotepad']) {
 	// Read command line output
     standardOutput = new ByteArrayOutputStream()
     group = 'test_testar_workflow'
-    description ='runTestDesktopGenericProcessNameSuspiciousTitle'
+    description ='runTestDesktopGenericProcessNameSuspiciousTag'
     workingDir 'target/install/testar/bin'
     commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_process_and_suspicious" SuspiciousTags=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=SUT_PROCESS_NAME SUTConnectorValue="notepad.exe" Sequences=1 SequenceLength=2'
     doLast {
@@ -138,7 +138,7 @@ task runTestDesktopGenericProcessNameSuspiciousTitle(type: Exec, dependsOn:['ins
 
 		// Use Format (for English and Spanish)
         if(output.readLines().any{line->line.contains("Discovered suspicious widget 'Title' : 'Format")}) {
-            println "\n${output} \nTESTAR has successfully connect with SUT_PROCESS_NAME and detected Format Suspicious Title! "
+            println "\n${output} \nTESTAR has successfully connect with SUT_PROCESS_NAME and detected Format Suspicious Tag! "
             // kill notepad process
             ext.process = new ProcessBuilder().command('cmd', '/c', 'taskkill /IM notepad.exe').start()
         } else {
@@ -150,12 +150,12 @@ task runTestDesktopGenericProcessNameSuspiciousTitle(type: Exec, dependsOn:['ins
 }
 
 // Verify that TESTAR correctly connects using windows title
-// To be sure, connect with windows title and detect Format suspicious title
-task runTestDesktopGenericTitleNameSuspiciousTitle(type: Exec, dependsOn:['installDist','runNotepad']) {
+// To be sure, connect with windows title and detect Format suspicious tag Title
+task runTestDesktopGenericTitleNameSuspiciousTag(type: Exec, dependsOn:['installDist','runNotepad']) {
 	// Read command line output
     standardOutput = new ByteArrayOutputStream()
     group = 'test_testar_workflow'
-    description ='runTestDesktopGenericTitleNameSuspiciousTitle'
+    description ='runTestDesktopGenericTitleNameSuspiciousTag'
     workingDir 'target/install/testar/bin'
     commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_desktop_generic AlwaysCompile=true ApplicationName="notepad_title_and_suspicious" SuspiciousTags=".*[fF]ormat.*|.*[fF]ormato.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate SUTConnector=SUT_WINDOW_TITLE SUTConnectorValue="Notepad" Sequences=1 SequenceLength=2'
     doLast {
@@ -163,7 +163,7 @@ task runTestDesktopGenericTitleNameSuspiciousTitle(type: Exec, dependsOn:['insta
 
 		// Use Format (for English and Spanish)
         if(output.readLines().any{line->line.contains("Discovered suspicious widget 'Title' : 'Format")}) {
-            println "\n${output} \nTESTAR has successfully connect with SUT_WINDOW_TITLE and detected Format Suspicious Title! "
+            println "\n${output} \nTESTAR has successfully connect with SUT_WINDOW_TITLE and detected Format Suspicious Tag! "
             // kill notepad process
             ext.process = new ProcessBuilder().command('cmd', '/c', 'taskkill /IM notepad.exe').start()
         } else {
@@ -281,12 +281,12 @@ task runTestDesktopGenericStateModelCustomAbstraction(type: Exec, dependsOn: cre
 }
 
 // Verify that TESTAR correctly executes chromedriver
-// To be sure, connect to ou.nl and detect Onderwijs suspicious title
-task runTestWebdriverSuspiciousTitle(type: Exec) {
+// To be sure, connect to ou.nl and detect Onderwijs suspicious tag ValuePattern
+task runTestWebdriverSuspiciousTag(type: Exec) {
 	// Read command line output
     standardOutput = new ByteArrayOutputStream()
     group = 'test_testar_workflow'
-    description ='runTestWebdriverSuspiciousTitle'
+    description ='runTestWebdriverSuspiciousTag'
     workingDir 'target/install/testar/bin'
     commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_webdriver_generic AlwaysCompile=true ApplicationName="webdriver_and_suspicious" TagsForSuspiciousOracle="NotExist;ValuePattern" SuspiciousTags=".*[oO]nderwijs.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate Sequences=1 SequenceLength=2'
     doLast {
@@ -294,7 +294,7 @@ task runTestWebdriverSuspiciousTitle(type: Exec) {
 
 		// Use Onderwijs
         if(output.readLines().any{line->line.contains("Discovered suspicious widget 'ValuePattern' : 'https://www.ou.nl/onderwijs")}) {
-            println "\n${output} \nTESTAR has successfully connect with WEB_DRIVER and detected Onderwijs Suspicious Title! "
+            println "\n${output} \nTESTAR has successfully connect with WEB_DRIVER and detected Onderwijs Suspicious Tag! "
         } else {
             throw new GradleException("\n${output} \nERROR: TESTAR didnt connect with WEB_DRIVER")
         }


### PR DESCRIPTION
- Configure 01_desktop_calculator protocol
- First 02_webdriver_parabank protocol changes
- Update default Spy mode properties
- Disable dialog Misc panel
- Allow creating Tag objects with a description
- Add a description for each ConfigTags
- Refactor Settings structure (main, secondary, other) settings
- Rename SuspiciousTitles to SuspiciousTags
- Remove ConfigTags that are not implemented in the code (ExecuteActions, DrawWidgetUnderCursor, DrawWidgetInfo, VisualizeSelectedAction, ShowSettingsAfterTest, TestGenerator, AlgorithmFormsFilling, TypingTextsForExecutedAction, DrawWidgetTree, ExplorationSampleInterval, ForceToSequenceLength, NonReactingUIThreshold, OfflineGraphConversion, StateScreenshotSimilarityThreshold, UnattendedTests)