### PR TITLE
Action selector adapter class#348

### DIFF
--- a/testar/resources/settings/desktop_generic_action_selector/Protocol_desktop_generic_action_selector.java
+++ b/testar/resources/settings/desktop_generic_action_selector/Protocol_desktop_generic_action_selector.java
@@ -30,11 +30,7 @@
 
 import java.util.Set;
 
-import org.testar.DerivedActions;
-import org.testar.IActionDerive;
-import org.testar.IActionExecutor;
-import org.testar.IActionSelector;
-import org.testar.PrioritizeNewActionsSelector;
+import org.testar.*;
 import org.testar.monkey.ConfigTags;
 import org.testar.monkey.Settings;
 import org.testar.monkey.alayer.Action;
@@ -51,7 +47,7 @@ import org.testar.simplestategraph.QLearningActionSelector;
  */
 public class Protocol_desktop_generic_action_selector extends DesktopProtocol {
 
-	private IActionSelector selector;
+	private ActionSelectorAdapter selector;
 
 	/**
 	 * Called once during the life time of TESTAR
@@ -78,7 +74,7 @@ public class Protocol_desktop_generic_action_selector extends DesktopProtocol {
 		 * Initialize a simple in-memory state model to prioritize the unvisited actions along the run. 
 		 * This implementation uses AbstractIDCustom abstraction to identify states and actions. 
 		 */
-		selector = new GuiStateGraphWithVisitedActions();
+		selector = new ActionSelectorAdapter(new GuiStateGraphWithVisitedActions());
 	}
 
 	/**
@@ -112,9 +108,7 @@ public class Protocol_desktop_generic_action_selector extends DesktopProtocol {
 		}
 
 		// Generate mode visualization purposes (Shift + Up)
-		if(selector instanceof IActionDerive) {
-			actions = ((IActionDerive) selector).deriveActions(actions);
-		}
+		actions = selector.deriveActions(actions);
 
 		//return the set of derived actions
 		return actions;
@@ -153,17 +147,7 @@ public class Protocol_desktop_generic_action_selector extends DesktopProtocol {
 	 */
 	@Override
 	protected boolean executeAction(SUT system, State state, Action action){
-		if(selector instanceof IActionExecutor)
-		{
-			((IActionExecutor) selector).executeAction(action);
-		}
-
-		if(selector instanceof PrioritizeNewActionsSelector)
-		{
-			System.out.println("Executed action: " + action.get(Tags.Desc, "NoCurrentDescAvailable")
-			+ " -- Times executed: " + ((PrioritizeNewActionsSelector) selector).timesExecuted(action));
-		}
-
+		selector.executeAction(action);
 		return super.executeAction(system, state, action);
 	}
 }

--- a/testar/resources/settings/desktop_generic_action_selector/Protocol_desktop_generic_action_selector.java
+++ b/testar/resources/settings/desktop_generic_action_selector/Protocol_desktop_generic_action_selector.java
@@ -31,23 +31,20 @@
 import java.util.Set;
 
 import org.testar.*;
-import org.testar.monkey.ConfigTags;
 import org.testar.monkey.Settings;
 import org.testar.monkey.alayer.Action;
 import org.testar.monkey.alayer.SUT;
 import org.testar.monkey.alayer.State;
-import org.testar.monkey.alayer.Tags;
 import org.testar.monkey.alayer.exceptions.ActionBuildException;
 import org.testar.protocols.DesktopProtocol;
 import org.testar.simplestategraph.GuiStateGraphWithVisitedActions;
-import org.testar.simplestategraph.QLearningActionSelector;
 
 /**
  * This protocol provides additional implementation to improve TESTAR action selection mechanism. 
  */
 public class Protocol_desktop_generic_action_selector extends DesktopProtocol {
 
-	private ActionSelectorAdapter selector;
+	private ActionSelectorProxy selector;
 
 	/**
 	 * Called once during the life time of TESTAR
@@ -74,7 +71,7 @@ public class Protocol_desktop_generic_action_selector extends DesktopProtocol {
 		 * Initialize a simple in-memory state model to prioritize the unvisited actions along the run. 
 		 * This implementation uses AbstractIDCustom abstraction to identify states and actions. 
 		 */
-		selector = new ActionSelectorAdapter(new GuiStateGraphWithVisitedActions());
+		selector = new ActionSelectorProxy(new GuiStateGraphWithVisitedActions());
 	}
 
 	/**

--- a/testar/resources/settings/webdriver_generic_action_selector/Protocol_webdriver_generic_action_selector.java
+++ b/testar/resources/settings/webdriver_generic_action_selector/Protocol_webdriver_generic_action_selector.java
@@ -28,6 +28,7 @@
  *
  */
 
+import org.testar.ActionSelectorAdapter;
 import org.testar.monkey.alayer.*;
 import org.testar.monkey.alayer.actions.AnnotatingActionCompiler;
 import org.testar.monkey.alayer.actions.StdActionCompiler;
@@ -37,8 +38,6 @@ import org.testar.monkey.alayer.webdriver.WdWidget;
 import org.testar.monkey.alayer.webdriver.enums.WdRoles;
 import org.testar.monkey.alayer.webdriver.enums.WdTags;
 import org.testar.plugin.NativeLinker;
-import org.testar.IActionExecutor;
-import org.testar.IActionSelector;
 import org.testar.action.priorization.SimilarityDetection;
 import org.testar.managers.InputDataManager;
 import org.testar.protocols.WebdriverProtocol;
@@ -55,7 +54,7 @@ import static org.testar.monkey.alayer.webdriver.Constants.scrollThick;
  */
 public class Protocol_webdriver_generic_action_selector extends WebdriverProtocol {
 
-	private IActionSelector selector;
+	private ActionSelectorAdapter selector;
 
 	/**
 	 * This method is invoked each time the TESTAR starts the SUT to generate a new sequence.
@@ -76,7 +75,7 @@ public class Protocol_webdriver_generic_action_selector extends WebdriverProtoco
 		 * As this value increases, there is less probability % of selecting a "similar" action. 
 		 * This selector is reset in each new sequence. 
 		 */
-		selector = new SimilarityDetection(deriveActions(system, state), 5);
+		selector = new ActionSelectorAdapter(new SimilarityDetection(deriveActions(system, state), 5));
 	}
 
 	/**
@@ -187,10 +186,7 @@ public class Protocol_webdriver_generic_action_selector extends WebdriverProtoco
 	 */
 	@Override
 	protected boolean executeAction(SUT system, State state, Action action) {
-		if(selector instanceof IActionExecutor)
-		{
-			((IActionExecutor) selector).executeAction(action);
-		}
+		selector.executeAction(action);
 		return super.executeAction(system, state, action);
 	}
 

--- a/testar/resources/settings/webdriver_generic_action_selector/Protocol_webdriver_generic_action_selector.java
+++ b/testar/resources/settings/webdriver_generic_action_selector/Protocol_webdriver_generic_action_selector.java
@@ -132,6 +132,9 @@ public class Protocol_webdriver_generic_action_selector extends WebdriverProtoco
 			}
 		}
 
+		// Use the action selector algorithm to filter some of the existing derived actions
+		actions = selector.deriveActions(actions);
+
 		return actions;
 	}
 
@@ -166,7 +169,7 @@ public class Protocol_webdriver_generic_action_selector extends WebdriverProtoco
 	 */
 	@Override
 	protected Action selectAction(State state, Set<Action> actions) {
-		// Use the desired action selector
+		// Use the desired action selector to select the next action to execute
 		Action action = selector.selectAction(state, actions);
 		// If no action is available with the selector, use the state model or a random selection
 		if(action == null)
@@ -186,7 +189,10 @@ public class Protocol_webdriver_generic_action_selector extends WebdriverProtoco
 	 */
 	@Override
 	protected boolean executeAction(SUT system, State state, Action action) {
+		// Update the action selector algorithm with the action were are going to execute
+		// This usually tracks which actions are being executed to reduce the probability in the next iteration
 		selector.executeAction(action);
+		// Then, execute the selected action
 		return super.executeAction(system, state, action);
 	}
 

--- a/testar/resources/settings/webdriver_generic_action_selector/Protocol_webdriver_generic_action_selector.java
+++ b/testar/resources/settings/webdriver_generic_action_selector/Protocol_webdriver_generic_action_selector.java
@@ -28,7 +28,7 @@
  *
  */
 
-import org.testar.ActionSelectorAdapter;
+import org.testar.ActionSelectorProxy;
 import org.testar.monkey.alayer.*;
 import org.testar.monkey.alayer.actions.AnnotatingActionCompiler;
 import org.testar.monkey.alayer.actions.StdActionCompiler;
@@ -54,7 +54,7 @@ import static org.testar.monkey.alayer.webdriver.Constants.scrollThick;
  */
 public class Protocol_webdriver_generic_action_selector extends WebdriverProtocol {
 
-	private ActionSelectorAdapter selector;
+	private ActionSelectorProxy selector;
 
 	/**
 	 * This method is invoked each time the TESTAR starts the SUT to generate a new sequence.
@@ -75,7 +75,7 @@ public class Protocol_webdriver_generic_action_selector extends WebdriverProtoco
 		 * As this value increases, there is less probability % of selecting a "similar" action. 
 		 * This selector is reset in each new sequence. 
 		 */
-		selector = new ActionSelectorAdapter(new SimilarityDetection(deriveActions(system, state), 5));
+		selector = new ActionSelectorProxy(new SimilarityDetection(deriveActions(system, state), 5));
 	}
 
 	/**

--- a/testar/src/org/testar/ActionSelectorAdapter.java
+++ b/testar/src/org/testar/ActionSelectorAdapter.java
@@ -1,0 +1,38 @@
+package org.testar;
+
+import org.testar.monkey.alayer.Action;
+import org.testar.monkey.alayer.State;
+
+import java.util.Set;
+
+public class ActionSelectorAdapter implements IActionSelector, IActionExecutor, IActionDerive{
+
+    private final Object selector;
+
+    public ActionSelectorAdapter(Object selector) {
+        this.selector = selector;
+    }
+
+    @Override
+    public Set<Action> deriveActions(Set<Action> actions) {
+        if (selector instanceof IActionDerive){
+            return ((IActionDerive) selector).deriveActions(actions);
+        }
+        return actions;
+    }
+
+    @Override
+    public void executeAction(Action action) {
+        if (selector instanceof IActionExecutor){
+            ((IActionExecutor) selector).executeAction(action);
+        }
+    }
+
+    @Override
+    public Action selectAction(State state, Set<Action> actions) {
+        if (selector instanceof IActionSelector){
+            return ((IActionSelector) selector).selectAction(state, actions);
+        }
+        return null;
+    }
+}

--- a/testar/src/org/testar/ActionSelectorProxy.java
+++ b/testar/src/org/testar/ActionSelectorProxy.java
@@ -5,11 +5,11 @@ import org.testar.monkey.alayer.State;
 
 import java.util.Set;
 
-public class ActionSelectorAdapter implements IActionSelector, IActionExecutor, IActionDerive{
+public class ActionSelectorProxy implements IActionSelector, IActionExecutor, IActionDerive{
 
     private final Object selector;
 
-    public ActionSelectorAdapter(Object selector) {
+    public ActionSelectorProxy(Object selector) {
         this.selector = selector;
     }
 

--- a/testar/src/org/testar/ActionSelectorProxy.java
+++ b/testar/src/org/testar/ActionSelectorProxy.java
@@ -1,3 +1,33 @@
+/***************************************************************************************************
+ *
+ * Copyright (c) 2023 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2023 Open Universiteit - www.ou.nl
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************************************/
+
 package org.testar;
 
 import org.testar.monkey.alayer.Action;
@@ -11,6 +41,7 @@ public class ActionSelectorProxy implements IActionSelector, IActionExecutor, IA
 
     public ActionSelectorProxy(Object selector) {
         this.selector = selector;
+        System.out.println("ActionSelector: " + this.selector.getClass().getSimpleName());
     }
 
     @Override

--- a/testar/src/org/testar/PrioritizeNewActionsSelector.java
+++ b/testar/src/org/testar/PrioritizeNewActionsSelector.java
@@ -31,6 +31,7 @@
 package org.testar;
 
 import org.testar.monkey.alayer.Action;
+import org.testar.monkey.alayer.Tags;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -145,6 +146,8 @@ public class PrioritizeNewActionsSelector extends RandomActionSelector implement
     @Override
     public void executeAction(Action action) {
         this.addExecutedAction(action);
+        System.out.println("Executed action: " + action.get(Tags.Desc, "NoCurrentDescAvailable")
+                + " -- Times executed: " + this.timesExecuted(action));
     }
 
     @Override

--- a/testar/src/org/testar/PrioritizeNewActionsSelector.java
+++ b/testar/src/org/testar/PrioritizeNewActionsSelector.java
@@ -61,6 +61,7 @@ public class PrioritizeNewActionsSelector extends RandomActionSelector implement
     private Map<Action, Integer> executedActions = new HashMap<>();
 
     public Set<Action> getPrioritizedActions(Set<Action> actions) {
+        System.out.println("---------------------------------------------------------");
         Set<Action> prioritizedActions = new HashSet<Action>();
         //checking if it is the first round of actions:
         if(previousActions==null) {
@@ -121,7 +122,7 @@ public class PrioritizeNewActionsSelector extends RandomActionSelector implement
         
         //saving the current actions for the next round:
         previousActions = actions;
-        return(prioritizedActions);
+        return prioritizedActions;
     }
     
     public void addExecutedAction(Action action){

--- a/testar/src/org/testar/RandomActionSelector.java
+++ b/testar/src/org/testar/RandomActionSelector.java
@@ -39,14 +39,23 @@ import java.util.Set;
 
 public class RandomActionSelector implements IActionSelector{
 
-    public static Action selectRandomAction(Set<Action> actions) {
-        long graphTime = System.currentTimeMillis();
-        Random rnd = new Random(graphTime);
-        return new ArrayList<Action>(actions).get(rnd.nextInt(actions.size()));
-    }
+	public static Action selectRandomActionUsingSystemTime(Set<Action> actions) {
+		long graphTime = System.currentTimeMillis();
+		Random rnd = new Random(graphTime);
+		return new ArrayList<Action>(actions).get(rnd.nextInt(actions.size()));
+	}
 
-    @Override
-    public Action selectAction(State state, Set<Action> actions) {
-        return selectRandomAction(actions);
-    }
+	public static Action selectRandomAction(Set<Action> actions) {
+		// Convert the Set to an ArrayList for easier indexing
+		ArrayList<Action> actionList = new ArrayList<>(actions);
+		// Generate a random index within the bounds of the ArrayList
+		int randomIndex = new Random().nextInt(actionList.size());
+		// Retrieve the Action at the generated index and return it
+		return actionList.get(randomIndex);
+	}
+
+	@Override
+	public Action selectAction(State state, Set<Action> actions) {
+		return selectRandomAction(actions);
+	}
 }

--- a/testar/src/org/testar/screenshotjson/JsonUtils.java
+++ b/testar/src/org/testar/screenshotjson/JsonUtils.java
@@ -1,7 +1,7 @@
 /***************************************************************************************************
  *
- * Copyright (c) 2019 - 2022 Universitat Politecnica de Valencia - www.upv.es
- * Copyright (c) 2019 - 2022 Open Universiteit - www.ou.nl
+ * Copyright (c) 2019 - 2023 Universitat Politecnica de Valencia - www.upv.es
+ * Copyright (c) 2019 - 2023 Open Universiteit - www.ou.nl
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -46,7 +46,10 @@ import java.util.Set;
 
 public class JsonUtils {
 
-    public static void createFullWidgetTreeJsonFile(State state, String fileNamePath){
+    public static boolean createFullWidgetTreeJsonFile(State state, String fileNamePath){
+    	// If the state has no children, do not continue
+    	if(state.childCount() == 0) return false;
+
         Set<FullWidgetInfoJsonObject> widgetTreeObjects = new HashSet<FullWidgetInfoJsonObject>();
         for(Widget widget:state){
             Set<Pair<String, String>> widgetTags = new HashSet<Pair<String, String>>();
@@ -56,17 +59,19 @@ public class JsonUtils {
             }
             widgetTreeObjects.add(new FullWidgetInfoJsonObject(widgetTags));
         }
-        writeJsonToFile(widgetTreeObjects,fileNamePath);
+        return writeJsonToFile(widgetTreeObjects,fileNamePath);
     }
 
-    public static void createWidgetInfoJsonFile(State state){
-    	
+    public static boolean createWidgetInfoJsonFile(State state){
+    	// If the state has no children, do not continue
+    	if(state.childCount() == 0) return false;
+
     	Rect sutRect;
     	try {
     		sutRect = (Rect) state.child(0).get(Tags.Shape, null);
     	}catch(NullPointerException e){
     		System.out.println("ERROR: Reading State bounds for JSON file");
-    		return;
+    		return false;
     	}
 
         Set<WidgetJsonObject> widgetJsonObjects = new HashSet<WidgetJsonObject>();
@@ -95,10 +100,10 @@ public class JsonUtils {
         ScreenshotWidgetJsonObject screenshotWidgetJsonObject = new ScreenshotWidgetJsonObject(widgetJsonObjects, screenshotPath);
         String filePath = screenshotPath.substring(0, screenshotPath.lastIndexOf("."))+".json";
 
-        writeJsonToFile(screenshotWidgetJsonObject, filePath);
+        return writeJsonToFile(screenshotWidgetJsonObject, filePath);
     }
 
-    private static void writeJsonToFile(Object objectToWrite, String fileNamePath){
+    private static boolean writeJsonToFile(Object objectToWrite, String fileNamePath){
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         try{
             FileWriter fileWriter = new FileWriter(fileNamePath);
@@ -108,6 +113,8 @@ public class JsonUtils {
         }catch(Exception e){
             System.out.println("ERROR: Writing JSON into file failed!");
             e.printStackTrace();
+            return false;
         }
+        return true;
     }
 }

--- a/testar/src/org/testar/simplestategraph/GuiStateGraphForQlearning.java
+++ b/testar/src/org/testar/simplestategraph/GuiStateGraphForQlearning.java
@@ -67,12 +67,12 @@ public class GuiStateGraphForQlearning {
      * @return
      */
     protected Action getActionWithAbstractCustomId(Set<Action> actions, String abstractCustomActionId){
-        System.out.println("DEBUG: trying to find action with a matching ID:");
+        //System.out.println("DEBUG: trying to find action with a matching ID:");
         for(Action action:actions){
-            System.out.println("DEBUG: action.AbstractIDCustom="+action.get(Tags.AbstractIDCustom)+", idToMatch="+abstractCustomActionId);
+            //System.out.println("DEBUG: action.AbstractIDCustom="+action.get(Tags.AbstractIDCustom)+", idToMatch="+abstractCustomActionId);
             // find the action with abstractCustomId:
             if(action.get(Tags.AbstractIDCustom).equals(abstractCustomActionId)){
-                System.out.println("DEBUG: match found!");
+                //System.out.println("DEBUG: match found!");
                 return action;
             }
         }

--- a/testar/src/org/testar/simplestategraph/GuiStateGraphWithVisitedActions.java
+++ b/testar/src/org/testar/simplestategraph/GuiStateGraphWithVisitedActions.java
@@ -58,6 +58,7 @@ public class GuiStateGraphWithVisitedActions implements IActionSelector {
     //TODO move into a new action selector:
     @Override
     public Action selectAction(State state, Set<Action> actions){
+        System.out.println("---------------------------------------------------------");
         // saving the starting node of the graph:
         if(startingStateAbstractCustomId==null){
             startingStateAbstractCustomId=state.get(Tags.AbstractIDCustom);
@@ -119,6 +120,7 @@ public class GuiStateGraphWithVisitedActions implements IActionSelector {
         // saving the state and action for state transition after knowing the target state:
         previousActionAbstractCustomId = returnAction.get(Tags.AbstractIDCustom);
         previousStateAbstractCustomId = state.get(Tags.AbstractIDCustom);
+        System.out.println(this.getClass() + ": return selected action = " + returnAction.get(Tags.Desc, "NoDescAvailable"));
         return returnAction;
     }
 

--- a/testar/src/org/testar/simplestategraph/QLearningActionSelector.java
+++ b/testar/src/org/testar/simplestategraph/QLearningActionSelector.java
@@ -58,6 +58,7 @@ public class QLearningActionSelector implements IActionSelector {
 
     @Override
     public Action selectAction(State state, Set<Action> actions) {
+        System.out.println("---------------------------------------------------------");
         // saving the starting node of the graph:
         if(graph.startingStateAbstractCustomId==null){
             graph.startingStateAbstractCustomId=state.get(Tags.AbstractIDCustom);
@@ -69,18 +70,16 @@ public class QLearningActionSelector implements IActionSelector {
         // If it's a new state:
         if(currentQlearningGuiState==null) { // did not contain the state ID -> a new state
             // new state:
-//            System.out.println(this.getClass()+": selectAction(): new state");
             currentQlearningGuiState = graph.createQlearningGuiState(state, actions);
         }else{
             //update the actions of the state - for some reason the action IDs are changing:
             currentQlearningGuiState.updateActionIdsOfTheStateIntoModel(actions, R_MAX);
         }
 
-
-        System.out.println("DEBUG: state ID from model="+currentQlearningGuiState.getAbstractCustomStateId());
-       for(String id:currentQlearningGuiState.abstractCustomActionIdsAndQValues.keySet()){
-            System.out.println("DEBUG: id="+id+", Q-value="+currentQlearningGuiState.abstractCustomActionIdsAndQValues.get(id));
-       }
+//        System.out.println("DEBUG: state ID from model="+currentQlearningGuiState.getAbstractCustomStateId());
+//        for(String id:currentQlearningGuiState.abstractCustomActionIdsAndQValues.keySet()){
+//        	System.out.println("DEBUG: id="+id+", Q-value="+currentQlearningGuiState.abstractCustomActionIdsAndQValues.get(id));
+//        }
 
         // adding state transition to the graph: previous state + previous action = current state
         if(graph.previousStateAbstractCustomId!=null && graph.previousActionAbstractCustomId != null){ //else the first action and there is no transition yet
@@ -89,11 +88,11 @@ public class QLearningActionSelector implements IActionSelector {
                 System.out.println(this.getClass()+": ERROR: GuiStateGraphWithVisitedActions did not find previous state!");
             }else{
                 graph.qlearningGuiStates.remove(previousState);//removing the old version of the state
-//                System.out.println(this.getClass()+": new state transition: previousStateId="+previousStateAbstractCustomId+", targetStateId="+state.get(Tags.AbstractIDCustom)+", previousActionAbstractCustomId="+previousActionAbstractCustomId);
                 previousState.addStateTransition(new GuiStateTransition(graph.previousStateAbstractCustomId,state.get(Tags.AbstractIDCustom),graph.previousActionAbstractCustomId),gammaDiscount,currentQlearningGuiState.getMaxQValueOfTheState(actions));
                 graph.qlearningGuiStates.add(previousState);//adding the updated version of the state
             }
         }
+        
         Action returnAction = null;
         ArrayList<String> actionIdsWithMaxQvalue = currentQlearningGuiState.getActionsIdsWithMaxQvalue(actions);
         if(actionIdsWithMaxQvalue.size()==0){
@@ -101,12 +100,12 @@ public class QLearningActionSelector implements IActionSelector {
             returnAction = RandomActionSelector.selectRandomAction(actions);
         }else{
             //selecting randomly of the actionIDs that have max Q value:
-            System.out.println("DEBUG: IDs of actions with max Q value:");
-            for(String id:actionIdsWithMaxQvalue){
-                System.out.println("DEBUG: id="+id);
-            }
-            long graphTime = System.currentTimeMillis();
-            Random rnd = new Random(graphTime);
+//        	System.out.println("DEBUG: IDs of actions with max Q value:");
+//        	for(String id:actionIdsWithMaxQvalue){
+//        		System.out.println("DEBUG: id="+id);
+//        	}
+
+            Random rnd = new Random();
             String abstractCustomIdOfRandomAction = actionIdsWithMaxQvalue.get(rnd.nextInt(actionIdsWithMaxQvalue.size()));
             System.out.println("DEBUG: randomly chosen id="+abstractCustomIdOfRandomAction);
             System.out.println("DEBUG: stateID from state="+state.get(Tags.AbstractIDCustom));
@@ -124,6 +123,7 @@ public class QLearningActionSelector implements IActionSelector {
         // saving the state and action for state transition after knowing the target state:
         graph.previousActionAbstractCustomId = returnAction.get(Tags.AbstractIDCustom);
         graph.previousStateAbstractCustomId = state.get(Tags.AbstractIDCustom);
+        System.out.println("DEBUG: return selected action = " + returnAction.get(Tags.Desc, "NoDescAvailable"));
         return returnAction;
     }
 

--- a/testar/test/org/testar/action/selector/TestActionSelector.java
+++ b/testar/test/org/testar/action/selector/TestActionSelector.java
@@ -1,0 +1,254 @@
+package org.testar.action.selector;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.testar.ActionSelectorProxy;
+import org.testar.PrioritizeNewActionsSelector;
+import org.testar.monkey.Assert;
+import org.testar.monkey.alayer.Action;
+import org.testar.monkey.alayer.Rect;
+import org.testar.monkey.alayer.Roles;
+import org.testar.monkey.alayer.Tags;
+import org.testar.monkey.alayer.actions.AnnotatingActionCompiler;
+import org.testar.monkey.alayer.actions.StdActionCompiler;
+import org.testar.simplestategraph.GuiStateGraphWithVisitedActions;
+import org.testar.simplestategraph.QLearningActionSelector;
+import org.testar.stub.StateStub;
+import org.testar.stub.WidgetStub;
+
+public class TestActionSelector {
+
+	@Rule
+	public RepeatRule repeatRule = new RepeatRule();
+
+	private static StateStub state;
+	private static Set<Action> originalActions;
+	private static StdActionCompiler ac = new AnnotatingActionCompiler();
+
+	private static List<Action> firstSelectedActionFromPrioritizeSelector = new ArrayList<>();
+	private static List<Action> firstSelectedActionFromGuiGraphSelector = new ArrayList<>();
+	private static List<Action> firstSelectedActionFromQLearningSelector = new ArrayList<>();
+
+	@BeforeClass
+	public static void setup() {
+		state = new StateStub();
+		state.set(Tags.AbstractIDCustom, "stateAbstractIDCustom");
+		originalActions = new HashSet<>();
+
+		// First action-widget
+		WidgetStub firstWidget = new WidgetStub();
+		state.addChild(firstWidget);
+		firstWidget.setParent(state);
+
+		firstWidget.set(Tags.Shape, Rect.fromCoordinates(1, 1, 1, 1));
+		firstWidget.set(Tags.Role, Roles.Button);
+		firstWidget.set(Tags.Path, "[0,0,1]");
+		firstWidget.set(Tags.Desc, "firstWidget");
+		firstWidget.set(Tags.ConcreteID, "firstWidgetConcreteID");
+		firstWidget.set(Tags.ConcreteIDCustom, "firstWidgetConcreteIDCustom");
+		firstWidget.set(Tags.AbstractID, "firstWidgetAbstractID");
+		firstWidget.set(Tags.AbstractIDCustom, "firstWidgetAbstractIDCustom");
+
+		Action firstAction = ac.leftClickAt(firstWidget);
+		firstAction.set(Tags.ConcreteID, "firstActionConcreteID");
+		firstAction.set(Tags.ConcreteIDCustom, "firstActionConcreteIDCustom");
+		firstAction.set(Tags.AbstractID, "firstActionAbstractID");
+		firstAction.set(Tags.AbstractIDCustom, "firstActionAbstractIDCustom");
+		originalActions.add(firstAction);
+
+		// Second action-widget
+		WidgetStub secondWidget = new WidgetStub();
+		state.addChild(secondWidget);
+		secondWidget.setParent(state);
+
+		secondWidget.set(Tags.Shape, Rect.fromCoordinates(2, 2, 2, 2));
+		secondWidget.set(Tags.Role, Roles.Button);
+		secondWidget.set(Tags.Path, "[0,0,2]");
+		secondWidget.set(Tags.Desc, "secondWidget");
+		secondWidget.set(Tags.ConcreteID, "secondWidgetConcreteID");
+		secondWidget.set(Tags.ConcreteIDCustom, "secondWidgetConcreteIDCustom");
+		secondWidget.set(Tags.AbstractID, "secondWidgetAbstractID");
+		secondWidget.set(Tags.AbstractIDCustom, "secondWidgetAbstractIDCustom");
+
+		Action secondAction = ac.leftClickAt(secondWidget);
+		secondAction.set(Tags.ConcreteID, "secondActionConcreteID");
+		secondAction.set(Tags.ConcreteIDCustom, "secondActionConcreteIDCustom");
+		secondAction.set(Tags.AbstractID, "secondActionAbstractID");
+		secondAction.set(Tags.AbstractIDCustom, "secondActionAbstractIDCustom");
+		originalActions.add(secondAction);
+	}
+
+	@Test
+	@Repeat( times = 100 ) // Repeat to deal with action selection randomness
+	public void testPrioritizeNewActionsSelector() {
+		ActionSelectorProxy prioritizeSelector = new ActionSelectorProxy(new PrioritizeNewActionsSelector());
+
+		// First derivation must return both actions
+		Set<Action> firstDerivedActions = prioritizeSelector.deriveActions(originalActions);
+		Assert.isTrue(firstDerivedActions.size() == 2);
+		Action firstAction = prioritizeSelector.selectAction(state, firstDerivedActions);
+		Assert.isTrue(firstAction != null);
+		firstSelectedActionFromPrioritizeSelector.add(firstAction);
+		prioritizeSelector.executeAction(firstAction);
+
+		// Second derivation must return only the non-executed action
+		Set<Action> secondDerivedActions = prioritizeSelector.deriveActions(originalActions);
+		Assert.isTrue(secondDerivedActions.size() == 1);
+		Action secondAction = prioritizeSelector.selectAction(state, secondDerivedActions);
+		Assert.isTrue(secondAction != null);
+		prioritizeSelector.executeAction(secondAction);
+
+		// Check both selected actions were not the same ones
+		Assert.isTrue(firstAction.get(Tags.Desc, "NonDesc") != secondAction.get(Tags.Desc, "NonDesc"));
+
+		// Finally, third derivation must reset the actions and return both ones again
+		Set<Action> thirdDerivedActions = prioritizeSelector.deriveActions(originalActions);
+		Assert.isTrue(thirdDerivedActions.size() == 2);
+	}
+
+	@Test
+	@Repeat( times = 100 ) // Repeat to deal with action selection randomness
+	public void testGuiStateGraphWithVisitedActions() {
+		ActionSelectorProxy guiGraphSelector = new ActionSelectorProxy(new GuiStateGraphWithVisitedActions());
+
+		// First action derivation must return both actions
+		Set<Action> firstDerivedActions = guiGraphSelector.deriveActions(originalActions);
+		Assert.isTrue(firstDerivedActions.size() == 2);
+		Action firstAction = guiGraphSelector.selectAction(state, firstDerivedActions);
+		Assert.isTrue(firstAction != null);
+		firstSelectedActionFromGuiGraphSelector.add(firstAction);
+		guiGraphSelector.executeAction(firstAction);
+
+		// Second derivation must return both actions
+		Set<Action> secondDerivedActions = guiGraphSelector.deriveActions(originalActions);
+		Assert.isTrue(secondDerivedActions.size() == 2);
+		Action secondAction = guiGraphSelector.selectAction(state, secondDerivedActions);
+		Assert.isTrue(secondAction != null);
+		guiGraphSelector.executeAction(secondAction);
+
+		// Check both selected actions were not the same ones
+		Assert.isTrue(firstAction.get(Tags.Desc, "NonDesc") != secondAction.get(Tags.Desc, "NonDesc"));
+	}
+
+	@Test
+	@Repeat( times = 100 ) // Repeat to deal with action selection randomness
+	public void testQLearningActionSelector() {
+		ActionSelectorProxy qLearningSelector = new ActionSelectorProxy(new QLearningActionSelector(99, 0.5));
+
+		// First action derivation must return both actions
+		Set<Action> firstDerivedActions = qLearningSelector.deriveActions(originalActions);
+		Assert.isTrue(firstDerivedActions.size() == 2);
+		Action firstAction = qLearningSelector.selectAction(state, firstDerivedActions);
+		Assert.isTrue(firstAction != null);
+		firstSelectedActionFromQLearningSelector.add(firstAction);
+		qLearningSelector.executeAction(firstAction);
+
+		// Second derivation must return both actions
+		Set<Action> secondDerivedActions = qLearningSelector.deriveActions(originalActions);
+		Assert.isTrue(secondDerivedActions.size() == 2);
+		Action secondAction = qLearningSelector.selectAction(state, secondDerivedActions);
+		Assert.isTrue(secondAction != null);
+		qLearningSelector.executeAction(secondAction);
+
+		// Check both selected actions were not the same ones
+		Assert.isTrue(firstAction.get(Tags.Desc, "NonDesc") != secondAction.get(Tags.Desc, "NonDesc"));
+	}
+
+	@AfterClass
+	public static void testFirstActionWereRandom() {
+		// TESTAR used an internal System.currentTimeMillis method to determine the next random action to select. 
+		// This is not truly random...
+
+		// Invoking this System.currentTimeMillis during GUI testing if OK, because the interval of time is not small...
+		// BUT invoking this System.currentTimeMillis method multiple times within a small interval of time can provoke obtain the same action repeatedly. 
+
+		// So we need to test that "random" is effectively random :)
+		// At least in these JUnit tests
+
+		Map<String, Integer> countPrioritizeSelector = actionListCounter(firstSelectedActionFromPrioritizeSelector, "PrioritizeSelector");
+		Assert.isTrue(countPrioritizeSelector.size() == 2);
+
+		Map<String, Integer> countGuiGraphSelector = actionListCounter(firstSelectedActionFromGuiGraphSelector, "GuiGraphSelector");
+		Assert.isTrue(countGuiGraphSelector.size() == 2);
+
+		Map<String, Integer> countQLearningSelector = actionListCounter(firstSelectedActionFromQLearningSelector, "QLearningSelector");
+		Assert.isTrue(countQLearningSelector.size() == 2);
+	}
+
+	private static Map<String, Integer> actionListCounter(List<Action> actionList, String actionListName) {
+		// Create a HashMap to store the counts
+		Map<String, Integer> countMap = new HashMap<>();
+		// Loop through each element in the list and update the count in the HashMap
+		for (Action action : actionList) {
+			Integer count = countMap.get(action.get(Tags.Desc, "NonDesc"));
+			if (count == null) {
+				count = 0;
+			}
+			countMap.put(action.get(Tags.Desc, "NonDesc"), count + 1);
+		}
+
+		// Print the counts
+		System.out.println(actionListName);
+		for (Map.Entry<String, Integer> entry : countMap.entrySet()) {
+			System.out.println(entry.getKey() + ": " + entry.getValue());
+		}
+
+		return countMap;
+	}
+}
+
+//https://gist.github.com/fappel/8bcb2aea4b39ff9cfb6e
+//JUnit 4 TestRule to run a test repeatedly for a specified amount of repetitions
+//TODO: When migrate to JUnit 5 use the @RepeatedTest annotation
+
+@Retention( java.lang.annotation.RetentionPolicy.RUNTIME )
+@Target( { java.lang.annotation.ElementType.METHOD } )
+@interface Repeat {
+	public abstract int times();
+}
+
+class RepeatRule implements TestRule {
+
+	private static class RepeatStatement extends Statement {
+
+		private final int times;
+		private final Statement statement;
+
+		private RepeatStatement( int times, Statement statement ) {
+			this.times = times;
+			this.statement = statement;
+		}
+
+		@Override
+		public void evaluate() throws Throwable {
+			for( int i = 0; i < times; i++ ) {
+				statement.evaluate();
+			}
+		}
+	}
+
+	@Override
+	public Statement apply( Statement statement, Description description ) {
+		Statement result = statement;
+		Repeat repeat = description.getAnnotation( Repeat.class );
+		if( repeat != null ) {
+			int times = repeat.times();
+			result = new RepeatStatement( times, statement );
+		}
+		return result;
+	}
+}

--- a/testar/test/org/testar/screenshotjson/TestStateJsonUtils.java
+++ b/testar/test/org/testar/screenshotjson/TestStateJsonUtils.java
@@ -1,0 +1,19 @@
+package org.testar.screenshotjson;
+
+import org.junit.Test;
+import org.testar.monkey.Assert;
+import org.testar.stub.StateStub;
+
+public class TestStateJsonUtils {
+
+	@Test
+	public void testJsonWithEmptyState() {
+		// Test that an empty state does not break TESTAR when using JsonUtils
+		StateStub state = new StateStub();
+		boolean created = JsonUtils.createWidgetInfoJsonFile(state);
+		Assert.isTrue(!created);
+		created = JsonUtils.createFullWidgetTreeJsonFile(state, "");
+		Assert.isTrue(!created);
+	}
+
+}


### PR DESCRIPTION
- New class `ActionSelectorProxy` acts as a proxy for every action selector. Implementing all interfaces ensures that every method can be called, while the actual behaviour of the methods can be found in the action selector classes. If the action selector class does not implement the method, nothing happens.

More info about Proxy Design pattern [ here](https://refactoring.guru/design-patterns/proxy)

- Protocols were updated with the new class