### PR TITLE
Improve Settings values validation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -304,11 +304,22 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     
+    - name: Prepare TESTAR protocols
+      run: ./gradlew init_workflow_test
+    
     - name: Build TESTAR with Gradle
       run: ./gradlew build
     
     - name: Prepare installed distribution of TESTAR with Gradle
       run: ./gradlew installDist
+    
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt install -y xvfb x11-utils libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 xdotool
+    
+    - name: Run webdriver protocol and detect SuspiciousTag
+      run: xvfb-run ./gradlew runTestWebdriverSuspiciousTagUbuntu
 
   macos:
     runs-on: macos-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -335,8 +335,14 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     
+    - name: Prepare TESTAR protocols
+      run: ./gradlew init_workflow_test
+    
     - name: Build TESTAR with Gradle
       run: ./gradlew build
     
     - name: Prepare installed distribution of TESTAR with Gradle
       run: ./gradlew installDist
+    
+    - name: Run webdriver protocol and detect SuspiciousTag
+      run: ./gradlew runTestWebdriverSuspiciousTagMacOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 FROM selenium/standalone-chrome
 
-USER root
-RUN apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false update && apt-get install -y openjdk-16-jdk libxkbcommon-x11-0
+RUN sudo apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false update
+RUN sudo apt-get install -y openjdk-17-jdk libxkbcommon-x11-0
 
 ADD testar/target/distributions/testar.tar .
 
-ENV JAVA_HOME "/usr/lib/jvm/java-16-openjdk-amd64"
-ENV DISPLAY=":99.0"
+ENV JAVA_HOME "/usr/lib/jvm/java-17-openjdk-amd64"
+ENV DISPLAY=":99"
 
 COPY runImage /runImage
 COPY README.Docker /README.Docker
-RUN chmod 777 /runImage
+RUN sudo chmod 777 /runImage
+RUN sudo chmod -R 777 /testar
 
 CMD [ "sh", "/runImage"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
+# This selenium docker image already contains chromedriver and xvfb
 FROM selenium/standalone-chrome
 
+# Update image dependencies and java
 RUN sudo apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false update
 RUN sudo apt-get install -y openjdk-17-jdk libxkbcommon-x11-0
 
+# To include TESTAR in the docker image, we should have previously compiled testar
+# gradlew distTar do this task
 ADD testar/target/distributions/testar.tar .
 
 ENV JAVA_HOME "/usr/lib/jvm/java-17-openjdk-amd64"
 ENV DISPLAY=":99"
 
+# Prepare the TESTAR files and permissions
 COPY runImage /runImage
 COPY README.Docker /README.Docker
 RUN sudo chmod 777 /runImage

--- a/README.Docker
+++ b/README.Docker
@@ -8,8 +8,7 @@ Take care of setting ShowVisualSettingsDialog to False in the settings file as w
 Take care of the following settings in the used settings file:
 - Mode should be Generate
 - SUTConnectorValue should contain the reference "/usr/bin/chromedriver" (the internal chromedriver of the Docker container)
-- ShowSettingsAfterTest should be false
-- VisualizeSelectedAction should be false
+- VisualizeActions should be false
 - ShowVisualSettingsDialogOnStartup should be false
 - FlashFeedback should be false
 - ProtocolCompileDirectory should be set to a directory local to the image e.g. /tmp (this is where the compiled java files are written to)

--- a/android/src/org/testar/monkey/alayer/android/spy_visualization/OverlayVisualization.java
+++ b/android/src/org/testar/monkey/alayer/android/spy_visualization/OverlayVisualization.java
@@ -213,10 +213,12 @@ public class OverlayVisualization extends JLayeredPane {
             this.node = node;
             Widget widget = (Widget)node.getUserObject();
             Rect bounds = widget.get(AndroidTags.AndroidBounds);
-            this.setBounds((int)((((double)overlay.width)/overlay.originalWidth)*bounds.x()),
-                    (int)((((double)overlay.height)/overlay.originalHeight)*bounds.y()),
-                    (int)((((double)overlay.width)/overlay.originalWidth)*bounds.width()),
-                    (int)((((double)overlay.height)/overlay.originalHeight)*bounds.height()));
+            // Reduce 1 pixel of the sides of the widget that we highlight with colors
+            // This will avoid opaque bounds to cover the state image
+            this.setBounds((int)((((double)overlay.width)/overlay.originalWidth)*bounds.x()) +1 ,
+                    (int)((((double)overlay.height)/overlay.originalHeight)*bounds.y()) +1 ,
+                    (int)((((double)overlay.width)/overlay.originalWidth)*bounds.width()) -1 ,
+                    (int)((((double)overlay.height)/overlay.originalHeight)*bounds.height()) -1);
 
             //this.setOpaque(true);
             this.setBackground(new Color(0, 0, 255, 0));

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
         implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
         implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
         // https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java
-        implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.9.1'
+        implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.12.1'
         // https://mvnrepository.com/artifact/io.appium/java-client/8.3.0
         implementation group: 'io.appium', name: 'java-client', version: '8.3.0'
     }

--- a/runImage
+++ b/runImage
@@ -1,8 +1,11 @@
 #!/bin/sh
 cat /README.Docker
-echo "Start Xvfb"
-/opt/bin/start-xvfb.sh &
-sleep 2
+echo "Internal Docker Display is"
+echo $DISPLAY
+echo "whoami"
+whoami
+echo "Starting TESTAR..."
 cd /testar/bin
-./testar
+# Run TESTAR with the Xvfb server
+xvfb-run ./testar sse=webdriver_docker_parabank
 #sh -c "while true; do sleep 1; done"

--- a/runImage
+++ b/runImage
@@ -6,6 +6,15 @@ echo "whoami"
 whoami
 echo "Starting TESTAR..."
 cd /testar/bin
+###################################################################
 # Run TESTAR with the Xvfb server
-xvfb-run ./testar sse=webdriver_docker_parabank
+# Configure TESTAR protocol and settings trought command line
+###################################################################
+xvfb-run ./testar sse=02_webdriver_parabank Mode=Generate SUTConnector=WEB_DRIVER SUTConnectorValue=" ""/usr/bin/chromedriver"" ""https://para.testar.org/"" " Sequences=1 SequenceLength=10 ShowVisualSettingsDialogOnStartup=false VisualizeActions=false FlashFeedback=false ProtocolCompileDirectory="/tmp"
+###################################################################
+# Next command can be used for debugging purposes. 
+# Instead of running TESTAR in the docker container, 
+# you can make this container commands continuously sleep. 
+# Then, open a Command Line Interface inside the running container.
+###################################################################
 #sh -c "while true; do sleep 1; done"

--- a/testar/resources/settings/webdriver_security_analysis/Protocol_webdriver_security_analysis.java
+++ b/testar/resources/settings/webdriver_security_analysis/Protocol_webdriver_security_analysis.java
@@ -33,7 +33,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.HasDevTools;
-import org.openqa.selenium.devtools.v113.network.Network;
+import org.openqa.selenium.devtools.v116.network.Network;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testar.SutVisualization;

--- a/testar/src/org/testar/monkey/DefaultProtocol.java
+++ b/testar/src/org/testar/monkey/DefaultProtocol.java
@@ -57,6 +57,9 @@ import java.util.zip.GZIPInputStream;
 
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
 import org.testar.*;
 import org.testar.managers.NativeHookManager;
 import org.testar.reporting.Reporting;
@@ -426,7 +429,16 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 	private void popupMessage(String message) {
 		if(settings.get(ConfigTags.ShowVisualSettingsDialogOnStartup)) {
 			JFrame frame = new JFrame();
-			JOptionPane.showMessageDialog(frame, message);
+
+			JTextArea textArea = new JTextArea(message);
+			textArea.setWrapStyleWord(true);
+			textArea.setLineWrap(true);
+			textArea.setEditable(false);
+
+			JScrollPane scrollPane = new JScrollPane(textArea);
+			scrollPane.setPreferredSize(new java.awt.Dimension(400, 200));
+
+			JOptionPane.showMessageDialog(frame, scrollPane);
 		}
 	}
 
@@ -722,6 +734,16 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 			throw new SystemStartException(ioe);
 		}
 		String sutConnectorType = settings().get(ConfigTags.SUTConnector);
+
+		// WindowsTitle, ProcessName, and CommandLine must have a SUTConnectorValue:
+		String connectorValue = settings().get(ConfigTags.SUTConnectorValue);
+		if(connectorValue == null || connectorValue.length() == 0) {
+			String msg = "It seems that the SUTConnectorValue setting is null or empty!\n"
+					+ "Please provide a valid value for the SUTConnector: " + sutConnectorType;
+			popupMessage(msg);
+			throw new SystemStartException(msg);
+		}
+
 		if (sutConnectorType.equals(Settings.SUT_CONNECTOR_WINDOW_TITLE)) {
 			WindowsWindowTitleSutConnector sutConnector = new WindowsWindowTitleSutConnector(settings().get(ConfigTags.SUTConnectorValue), 
 					Math.round(settings().get(ConfigTags.StartupTime).doubleValue() * 1000.0), 
@@ -733,9 +755,6 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 					Math.round(settings().get(ConfigTags.StartupTime).doubleValue() * 1000.0));
 			return sutConnector.startOrConnectSut();
 		}else{
-			// COMMANDLINE and WebDriver SUT CONNECTOR:
-			Assert.hasTextSetting(settings().get(ConfigTags.SUTConnectorValue), "SUTConnectorValue");
-
 			//Read the settings to know if user wants to start the process listener
 			if(settings.get(ConfigTags.ProcessListenerEnabled)) {
 				enabledProcessListener = processListener.enableProcessListeners(settings);

--- a/testar/src/org/testar/monkey/DefaultProtocol.java
+++ b/testar/src/org/testar/monkey/DefaultProtocol.java
@@ -745,13 +745,13 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 		}
 
 		if (sutConnectorType.equals(Settings.SUT_CONNECTOR_WINDOW_TITLE)) {
-			WindowsWindowTitleSutConnector sutConnector = new WindowsWindowTitleSutConnector(settings().get(ConfigTags.SUTConnectorValue), 
+			SutConnectorWindowTitle sutConnector = new SutConnectorWindowTitle(settings().get(ConfigTags.SUTConnectorValue), 
 					Math.round(settings().get(ConfigTags.StartupTime).doubleValue() * 1000.0), 
 					builder,
 					settings().get(ConfigTags.ForceForeground));
 			return sutConnector.startOrConnectSut();
 		}else if (sutConnectorType.startsWith(Settings.SUT_CONNECTOR_PROCESS_NAME)) {
-			WindowsProcessNameSutConnector sutConnector = new WindowsProcessNameSutConnector(settings().get(ConfigTags.SUTConnectorValue), 
+			SutConnectorProcessName sutConnector = new SutConnectorProcessName(settings().get(ConfigTags.SUTConnectorValue), 
 					Math.round(settings().get(ConfigTags.StartupTime).doubleValue() * 1000.0));
 			return sutConnector.startOrConnectSut();
 		}else{
@@ -761,7 +761,7 @@ public class DefaultProtocol extends RuntimeControlsProtocol {
 			}
 
 			// for most windows applications and most jar files, this is where the SUT gets created!
-			WindowsCommandLineSutConnector sutConnector = new WindowsCommandLineSutConnector(settings.get(ConfigTags.SUTConnectorValue),
+			SutConnectorCommandLine sutConnector = new SutConnectorCommandLine(settings.get(ConfigTags.SUTConnectorValue),
 					enabledProcessListener, settings().get(ConfigTags.StartupTime)*1000, Math.round(settings().get(ConfigTags.StartupTime).doubleValue() * 1000.0), builder, settings.get(ConfigTags.FlashFeedback));
 			//TODO startupTime and maxEngageTime seems to be the same, except one is double and the other is long?
 			return sutConnector.startOrConnectSut();

--- a/testar/src/org/testar/monkey/Main.java
+++ b/testar/src/org/testar/monkey/Main.java
@@ -44,10 +44,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-
 import org.testar.monkey.alayer.exceptions.NoSuchTagException;
 import org.testar.monkey.alayer.windows.Windows10;
 import org.testar.plugin.NativeLinker;
@@ -119,11 +115,6 @@ public class Main {
 		// We only want to execute TESTAR one time with the selected settings.
 		if(!settings.get(ConfigTags.ShowVisualSettingsDialogOnStartup)){
 
-			// Verify settings regular expressions before starting TESTAR
-			verifyRegularExpressionSettings(settings, testSettingsFileName);
-
-			escapeSpecialCharactersInFileWritingSettings(settings);
-
 			setTestarDirectory(settings);
 
 			initCodingManager(settings);
@@ -139,11 +130,6 @@ public class Main {
 				// The dialog can change the test settings file, we need to reload the settings
 				testSettingsFileName = getTestSettingsFile();
 				settings = loadTestarSettings(args, testSettingsFileName);
-
-				// Verify settings regular expressions before starting TESTAR
-				verifyRegularExpressionSettings(settings, testSettingsFileName);
-
-				escapeSpecialCharactersInFileWritingSettings(settings);
 
 				setTestarDirectory(settings);
 
@@ -725,66 +711,4 @@ public class Main {
 		}
 	}
 
-	/**
-	 * Check if filter and oracles regular expressions are valid. 
-	 * 
-	 * @param settings
-	 * @return
-	 */
-	private static void verifyRegularExpressionSettings(Settings settings, String testSettingsFileName) {
-		StringBuilder invalidExpressions = new StringBuilder();
-
-		List<Tag<String>> regularExpressionTags = Arrays.asList(
-				ConfigTags.ProcessesToKillDuringTest,
-				ConfigTags.ClickFilter,
-				ConfigTags.SuspiciousTags,
-				ConfigTags.SuspiciousProcessOutput,
-				ConfigTags.ProcessLogs,
-				ConfigTags.WebConsoleErrorPattern,
-				ConfigTags.WebConsoleWarningPattern
-				);
-
-		for(Tag<String> tag : regularExpressionTags) {
-			try {
-				Pattern.compile(settings.get(tag));
-			} catch (PatternSyntaxException exception) {
-				invalidExpressions.append(System.getProperty("line.separator"));
-				invalidExpressions.append("Error! Your " + tag.name() + " is not a valid regular expression! " + settings.get(tag));
-			}
-		}
-
-		if(!invalidExpressions.toString().isEmpty()) {
-			invalidExpressions.append(System.getProperty("line.separator"));
-			invalidExpressions.append("Settings Initialization Error! An invalid regular expression was detected in the TESTAR settings: " + testSettingsFileName);
-			invalidExpressions.append(System.getProperty("line.separator"));
-			invalidExpressions.append("Settings Initialization Error! Please fix the expressions or remove all characters and start TESTAR again.");
-			invalidExpressions.append(System.getProperty("line.separator"));
-			throw new IllegalStateException(invalidExpressions.toString());
-		}
-	}
-
-	/**
-	 * Escape special characters in settings that are used to write directories or files. 
-	 * 
-	 * @param settings
-	 * @return
-	 */
-	private static void escapeSpecialCharactersInFileWritingSettings(Settings settings) {
-		List<Tag<String>> writeSystemTags = Arrays.asList(
-				ConfigTags.ApplicationName,
-				ConfigTags.ApplicationVersion
-				);
-
-		for(Tag<String> tag : writeSystemTags) {
-			Pattern p = Pattern.compile("[\\/?:*\"|><]");
-			Matcher m = p.matcher(settings.get(tag, ""));
-
-			if(m.find()) {
-				String value = settings.get(tag, "").replaceAll("[\\/?:*\"|><]", "_");
-				System.out.println(String.format("Info: Replacing %s special characters from %s to %s", 
-						tag.name(), settings.get(tag, ""), value));
-				settings.set(tag, value);
-			}
-		}
-	}
 }

--- a/testar/src/org/testar/monkey/SutConnectorCommandLine.java
+++ b/testar/src/org/testar/monkey/SutConnectorCommandLine.java
@@ -42,7 +42,7 @@ import org.testar.monkey.alayer.exceptions.SystemStartException;
 import org.testar.monkey.alayer.windows.WinApiException;
 import org.testar.plugin.NativeLinker;
 
-public class WindowsCommandLineSutConnector implements SutConnector {
+public class SutConnectorCommandLine implements SutConnector {
 
     private String SUTConnectorValue;
     private boolean processListenerEnabled;
@@ -53,7 +53,7 @@ public class WindowsCommandLineSutConnector implements SutConnector {
     private boolean flashFeedback;
     private static final Logger logger = LogManager.getLogger();
 
-    public WindowsCommandLineSutConnector(String SUTConnectorValue, boolean processListenerEnabled, double startupTime, long maxEngageTime, StateBuilder builder, boolean flashFeedback) {
+    public SutConnectorCommandLine(String SUTConnectorValue, boolean processListenerEnabled, double startupTime, long maxEngageTime, StateBuilder builder, boolean flashFeedback) {
         this.SUTConnectorValue = SUTConnectorValue;
         this.processListenerEnabled = processListenerEnabled;
         this.startupTime = startupTime;

--- a/testar/src/org/testar/monkey/SutConnectorWindowTitle.java
+++ b/testar/src/org/testar/monkey/SutConnectorWindowTitle.java
@@ -30,42 +30,74 @@
 
 package org.testar.monkey;
 
-import org.testar.monkey.alayer.SUT;
-import org.testar.monkey.alayer.Tags;
+import org.testar.CodingManager;
+import org.testar.ProtocolUtil;
+import org.testar.monkey.alayer.*;
+import org.testar.monkey.alayer.exceptions.StateBuildException;
 import org.testar.monkey.alayer.exceptions.SystemStartException;
 import org.testar.plugin.NativeLinker;
 
 import java.util.List;
 
-public class WindowsProcessNameSutConnector implements SutConnector {
+public class SutConnectorWindowTitle implements SutConnector {
 
-    private String processName;
-    private double maxEngageTime;
+    private String windowTitle;
+    private double maxEngangeTime;
+    private StateBuilder builder;
+    private boolean forceToForeground;
 
-    public WindowsProcessNameSutConnector(String processName, double maxEngageTime) {
-        this.processName = processName;
-        this.maxEngageTime = maxEngageTime;
+    public SutConnectorWindowTitle(String windowTitle, double maxEngangeTime, StateBuilder builder, boolean forceToForeground) {
+        this.windowTitle = windowTitle;
+        this.maxEngangeTime = maxEngangeTime;
+        this.builder = builder;
+        this.forceToForeground = forceToForeground;
     }
 
     @Override
     public SUT startOrConnectSut() throws SystemStartException {
         List<SUT> suts = null;
+        State state; Role role; String title;
         long now = System.currentTimeMillis();
         do{
             Util.pauseMs(100);
             suts = NativeLinker.getNativeProcesses();
             if (suts != null){
-                String desc;
                 for (SUT theSUT : suts){
-                    desc = theSUT.get(Tags.Desc, null);
-                    if (desc != null && desc.contains(processName)){
-                        System.out.println("SUT with Process Name -" + processName + "- DETECTED!");
-                        return theSUT;
+                    state = getStateByWindowTitle(theSUT);
+                    // If the system is in the foreground or if the option to force to the foreground is enabled
+                    if (state.get(Tags.Foreground) || forceToForeground){
+                        for (Widget w : state){
+                            role = w.get(Tags.Role, null);
+                            if (role != null && Role.isOneOf(role, NativeLinker.getNativeRole_Window())){
+                                title = w.get(Tags.Title, null);
+                                if (title != null && title.contains(windowTitle)){
+                                    System.out.println("SUT with Window Title -" + windowTitle + "- DETECTED!");
+                                    return theSUT;
+                                }
+                            }
+                        }
                     }
                 }
             }
-        } while (System.currentTimeMillis() - now < maxEngageTime);
-        throw new SystemStartException("SUT Process Name not found!: -" + processName + "-");
+        } while (System.currentTimeMillis() - now < maxEngangeTime);
+        throw new SystemStartException("SUT Window Title not found!: -" + windowTitle + "-");
+    }
+
+    protected State getStateByWindowTitle(SUT system) throws StateBuildException {
+        Assert.notNull(system);
+        State state = builder.apply(system);
+
+        CodingManager.buildIDs(state);
+
+        Shape viewPort = state.get(Tags.Shape, null);
+        if(viewPort != null){
+            state.set(Tags.ScreenshotPath, ProtocolUtil.getStateshot(state));
+            //Don't include WdProtocolUtil option because TESTAR doesn't connect to webdrivers through the windows title
+        }
+
+        state = ProtocolUtil.calculateZIndices(state);
+
+        return state;
     }
 
 }

--- a/testar/src/org/testar/monkey/WindowsProcessNameSutConnector.java
+++ b/testar/src/org/testar/monkey/WindowsProcessNameSutConnector.java
@@ -49,7 +49,6 @@ public class WindowsProcessNameSutConnector implements SutConnector {
 
     @Override
     public SUT startOrConnectSut() throws SystemStartException {
-        Assert.hasTextSetting(processName, "SUTConnectorValue");
         List<SUT> suts = null;
         long now = System.currentTimeMillis();
         do{

--- a/testar/src/org/testar/monkey/WindowsWindowTitleSutConnector.java
+++ b/testar/src/org/testar/monkey/WindowsWindowTitleSutConnector.java
@@ -55,7 +55,6 @@ public class WindowsWindowTitleSutConnector implements SutConnector {
 
     @Override
     public SUT startOrConnectSut() throws SystemStartException {
-        Assert.hasTextSetting(windowTitle, "SUTConnectorValue");
         List<SUT> suts = null;
         State state; Role role; String title;
         long now = System.currentTimeMillis();

--- a/testar/src/org/testar/reporting/HtmlSequenceReport.java
+++ b/testar/src/org/testar/reporting/HtmlSequenceReport.java
@@ -151,6 +151,9 @@ public class HtmlSequenceReport implements Reporting{
         if(firstStateAdded){
             if(firstActionsAdded){
                 writeStateIntoReport(state);
+            }else if(state.get(Tags.OracleVerdict, Verdict.OK).severity() > Verdict.SEVERITY_OK){
+                //if the first state contains a failure, write the same state in case it was a login
+                writeStateIntoReport(state);
             }else{
                 //don't write the state as it is the same - getState is run twice in the beginning, before the first action
             }

--- a/testar/src/org/testar/securityanalysis/oracles/HeaderAnalysisSecurityOracle.java
+++ b/testar/src/org/testar/securityanalysis/oracles/HeaderAnalysisSecurityOracle.java
@@ -31,8 +31,8 @@
 package org.testar.securityanalysis.oracles;
 
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v113.network.Network;
-import org.openqa.selenium.devtools.v113.network.model.Headers;
+import org.openqa.selenium.devtools.v116.network.Network;
+import org.openqa.selenium.devtools.v116.network.model.Headers;
 import org.testar.monkey.alayer.Verdict;
 import org.testar.monkey.alayer.webdriver.WdDriver;
 import org.testar.securityanalysis.NetworkCollector;

--- a/testar/src/org/testar/securityanalysis/oracles/SqlInjectionSecurityOracle.java
+++ b/testar/src/org/testar/securityanalysis/oracles/SqlInjectionSecurityOracle.java
@@ -31,7 +31,7 @@
 package org.testar.securityanalysis.oracles;
 
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v113.network.Network;
+import org.openqa.selenium.devtools.v116.network.Network;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testar.monkey.alayer.*;
 import org.testar.monkey.alayer.actions.WdSecurityInjectionAction;

--- a/testar/src/org/testar/settingsdialog/SettingsDialog.java
+++ b/testar/src/org/testar/settingsdialog/SettingsDialog.java
@@ -68,7 +68,7 @@ import static javax.swing.UIManager.*;
 public class SettingsDialog extends JFrame implements Observer {
   private static final long serialVersionUID = 5156320008281200950L;
 
-  static final String TESTAR_VERSION = "2.6.5 (27-Jun-2023)";
+  static final String TESTAR_VERSION = "2.6.6 (15-Sep-2023)";
 
   private String settingsFile;
   private Settings settings;

--- a/testar/test/org/testar/monkey/TestApplicationNameSettings.java
+++ b/testar/test/org/testar/monkey/TestApplicationNameSettings.java
@@ -1,0 +1,36 @@
+package org.testar.monkey;
+
+import static org.testar.monkey.ConfigTags.ApplicationName;
+import static org.testar.monkey.ConfigTags.ApplicationVersion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class TestApplicationNameSettings {
+
+	@Test
+	public void validApplicationNameValues() {
+		List<Pair<?, ?>> tags = new ArrayList<Pair<?, ?>>();
+		tags.add(Pair.from(ApplicationName, "desktop_app"));
+		tags.add(Pair.from(ApplicationVersion, "v1.0.0"));
+
+		Settings settings = new Settings(tags, new Properties());
+		Assert.isTrue(settings.get(ConfigTags.ApplicationName, "").equals("desktop_app"));
+		Assert.isTrue(settings.get(ConfigTags.ApplicationVersion, "").equals("v1.0.0"));
+	}
+
+	@Test
+	public void escapedApplicationNameValues() {
+		List<Pair<?, ?>> tags = new ArrayList<Pair<?, ?>>();
+		tags.add(Pair.from(ApplicationName, "desktop_app_.\\./.?.:.*.\".|.>.<."));
+		tags.add(Pair.from(ApplicationVersion, "v1.0.0_.\\./.?.:.*.\".|.>.<."));
+
+		Settings settings = new Settings(tags, new Properties());
+		Assert.isTrue(settings.get(ConfigTags.ApplicationName, "").equals("desktop_app_._._._._._._._._._._"));
+		Assert.isTrue(settings.get(ConfigTags.ApplicationVersion, "").equals("v1.0.0_._._._._._._._._._._"));
+	}
+
+}

--- a/testar/test/org/testar/monkey/TestRegularExpressionSettings.java
+++ b/testar/test/org/testar/monkey/TestRegularExpressionSettings.java
@@ -1,74 +1,15 @@
 package org.testar.monkey;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.testar.monkey.alayer.Tag;
-import com.github.stefanbirkner.systemlambda.SystemLambda;
 
 public class TestRegularExpressionSettings {
 
-	private static String test_protocol = "webdriver_generic";
-	private static File temp_settings = new File(Main.settingsDir);
-	private static File temp_protocol = new File(Main.settingsDir + File.separator + test_protocol);
-	private static List<File> initialOutputFiles = new ArrayList<>();
-
-	@BeforeClass
-	public static void initialDirectory() {
-		// Create the protocol temp directory
-		File protocolDir = new File(Main.testarDir + "resources" + File.separator + "settings" + File.separator + test_protocol);
-		try {
-			FileUtils.copyDirectory(protocolDir, temp_protocol);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-
-		File output = new File(Main.outputDir);
-		if(output.exists()) {
-			for (File seq : output.listFiles()) {
-				initialOutputFiles.add(seq);
-			}
-		}
-	}
-
-	@AfterClass
-	public static void cleanUp() {
-		// Clean the settings temp directory
-		try {
-			FileUtils.deleteDirectory(temp_settings);
-		} catch (IOException e1) {
-			e1.printStackTrace();
-		}
-		// Delete all the sequence output directories that were created in these Unit tests
-		File output = new File(Main.outputDir);
-		if(output.exists()) {
-			for (File seq : output.listFiles()) {
-				if(!initialOutputFiles.contains(seq)) {
-					try {
-						FileUtils.deleteDirectory(seq);
-					} catch (IOException e) {
-						e.printStackTrace();
-					}
-				}
-			}
-			if(initialOutputFiles.isEmpty()) {
-				try {
-					FileUtils.deleteDirectory(output);
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-			}
-		}
-	}
-
-	private String[] args = {"testar", "sse="+test_protocol, "ShowVisualSettingsDialogOnStartup=false", "AlwaysCompile=true", "Mode=Generate", "Sequences=0", "SequenceLength=0", "ClickFilter=.*.*"};
 	private List<Tag<String>> regularExpressionTags = Arrays.asList(
 			ConfigTags.ProcessesToKillDuringTest,
 			ConfigTags.ClickFilter,
@@ -81,40 +22,40 @@ public class TestRegularExpressionSettings {
 
 	@Test
 	public void validRegularExpressionSetting() {
+		List<Pair<?, ?>> tags = new ArrayList<Pair<?, ?>>();
 		for(Tag<String> tag : regularExpressionTags) {
-			args[args.length - 1] = tag + "=.*[aA].*|.*bc.*";
-			String exceptionMessage = "";
-			try {
-				int status = SystemLambda.catchSystemExit(() -> {
-					// We expect a System.exit(0) from TESTAR Main.stopTestar
-					Main.main(args);
-				});
-				// Verify this is system exit 0
-				Assert.isTrue(status == 0);
-			} catch (Exception e) {
-				exceptionMessage = e.getMessage();
-			}
-			// Because the pattern is correct, we should not get any exception messages
-			System.out.println(exceptionMessage);
-			Assert.isTrue(exceptionMessage.isEmpty());
+			tags.add(Pair.from(tag, ".*[aA].*|.*bc.*"));
+		}
+
+		// When initializing the regex settings with correct values
+		Settings settings = new Settings(tags, new Properties());
+
+		// All ConfigTags settings were set with the desired correct value
+		for(Tag<String> tag : regularExpressionTags) {
+			System.out.println(tag + " valid regex: " + settings.get(tag, ""));
+			Assert.isTrue(settings.get(tag, "").equals(".*[aA].*|.*bc.*"));
 		}
 	}
 
 	@Test
 	public void invalidRegularExpressionSetting() {
 		for(Tag<String> tag : regularExpressionTags) {
-			args[args.length - 1] = tag + "=.**[aA].*|.*bc.*";
+			List<Pair<?, ?>> tags = new ArrayList<Pair<?, ?>>();
+			tags.add(Pair.from(tag, ".**[aA].*|.*bc.*"));
+
 			String exceptionMessage = ""; 
 			try {
-				// When the regular expression is not valid, TESTAR throws an exception and does not execute System.exit(0)
-				Main.main(args);
-			} catch (IllegalStateException | IOException e) {
+				// When the settings regular expression is not valid, 
+				// TESTAR throws an IllegalStateException
+				new Settings(tags, new Properties());
+			} catch (IllegalStateException e) {
 				exceptionMessage = e.getMessage();
 			}
-			// Because the pattern is NOT correct, we should get an exception message
+
+			// Because the regex is NOT correct, we should get an exception message
 			System.out.println(exceptionMessage);
 			Assert.hasText(exceptionMessage);
-			Assert.isTrue(exceptionMessage.contains(tag + " is not a valid regular expression"));
+			Assert.isTrue(exceptionMessage.contains(tag + " setting is not a valid regular expression"));
 		}
 	}
 

--- a/testar/workflow.gradle
+++ b/testar/workflow.gradle
@@ -322,6 +322,26 @@ task runTestWebdriverSuspiciousTagUbuntu(type: Exec) {
     }
 }
 
+// macOS: Verify that TESTAR correctly executes chromedriver
+task runTestWebdriverSuspiciousTagMacOS(type: Exec) {
+	// Read command line output
+    standardOutput = new ByteArrayOutputStream()
+    group = 'test_testar_workflow'
+    description ='runTestWebdriverSuspiciousTagMacOS'
+    workingDir 'target/install/testar/bin'
+    commandLine 'bash', '-c', './testar sse=test_gradle_workflow_webdriver_generic SUTConnectorValue=" ""/usr/local/share/chromedriver-mac-x64/chromedriver"" ""https://www.ou.nl"" " FlashFeedback=false AlwaysCompile=true ApplicationName="webdriver_and_suspicious" TagsForSuspiciousOracle="NotExist;ValuePattern" SuspiciousTags=".*[oO]nderwijs.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate Sequences=1 SequenceLength=2'
+    doLast {
+        String output = standardOutput.toString()
+
+		// Use Onderwijs
+        if(output.readLines().any{line->line.contains("Discovered suspicious widget 'ValuePattern' : 'https://www.ou.nl/onderwijs")}) {
+            println "\n${output} \nTESTAR has successfully connect with WEB_DRIVER and detected Onderwijs Suspicious Tag! "
+        } else {
+            throw new GradleException("\n${output} \nERROR: TESTAR didnt connect with WEB_DRIVER")
+        }
+    }
+}
+
 // Connect to para.testar.org, make a login and detect the browser console error message
 task runTestWebdriverParabankLoginAndConsoleError(type: Exec) {
 	// Read command line output

--- a/testar/workflow.gradle
+++ b/testar/workflow.gradle
@@ -280,6 +280,7 @@ task runTestDesktopGenericStateModelCustomAbstraction(type: Exec, dependsOn: cre
     }
 }
 
+// Windows OS
 // Verify that TESTAR correctly executes chromedriver
 // To be sure, connect to ou.nl and detect Onderwijs suspicious tag ValuePattern
 task runTestWebdriverSuspiciousTag(type: Exec) {
@@ -289,6 +290,26 @@ task runTestWebdriverSuspiciousTag(type: Exec) {
     description ='runTestWebdriverSuspiciousTag'
     workingDir 'target/install/testar/bin'
     commandLine 'cmd', '/c', 'testar sse=test_gradle_workflow_webdriver_generic AlwaysCompile=true ApplicationName="webdriver_and_suspicious" TagsForSuspiciousOracle="NotExist;ValuePattern" SuspiciousTags=".*[oO]nderwijs.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate Sequences=1 SequenceLength=2'
+    doLast {
+        String output = standardOutput.toString()
+
+		// Use Onderwijs
+        if(output.readLines().any{line->line.contains("Discovered suspicious widget 'ValuePattern' : 'https://www.ou.nl/onderwijs")}) {
+            println "\n${output} \nTESTAR has successfully connect with WEB_DRIVER and detected Onderwijs Suspicious Tag! "
+        } else {
+            throw new GradleException("\n${output} \nERROR: TESTAR didnt connect with WEB_DRIVER")
+        }
+    }
+}
+
+// Linux OS
+task runTestWebdriverSuspiciousTagUbuntu(type: Exec) {
+	// Read command line output
+    standardOutput = new ByteArrayOutputStream()
+    group = 'test_testar_workflow'
+    description ='runTestWebdriverSuspiciousTagUbuntu'
+    workingDir 'target/install/testar/bin'
+    commandLine 'bash', '-c', './testar sse=test_gradle_workflow_webdriver_generic SUTConnectorValue=" ""/usr/local/share/chromedriver-linux64/chromedriver"" ""https://www.ou.nl"" " FlashFeedback=false AlwaysCompile=true ApplicationName="webdriver_and_suspicious" TagsForSuspiciousOracle="NotExist;ValuePattern" SuspiciousTags=".*[oO]nderwijs.*" ShowVisualSettingsDialogOnStartup=false Mode=Generate Sequences=1 SequenceLength=2'
     doLast {
         String output = standardOutput.toString()
 

--- a/webdriver/src/org/testar/monkey/alayer/webdriver/WdDriver.java
+++ b/webdriver/src/org/testar/monkey/alayer/webdriver/WdDriver.java
@@ -90,6 +90,8 @@ public class WdDriver extends SUTBase {
     String driverPath = parts[0].replace("\"", "");
 
     String osName = System.getProperty("os.name");
+    //TODO: Check what is this condition aim to change in the SUTConnectorValue
+    //TODO: If not sure just remove and refactor because this can provoke IndexOutOfBoundsException 
     if(!driverPath.contains(".exe") && osName.contains("Windows")) {
     	driverPath = sutConnector.substring(0, sutConnector.indexOf(".exe")+4);
     	driverPath = driverPath.replace("\"", "");


### PR DESCRIPTION
1. Extend the default TESTAR settings validation that only parses the value of different settings (Double, Integer, Boolean, etc.)

To additionally validate if the users are providing correct input values for the different groups of settings:

- `AbstractStateAttributes` validate custom state tags for state abstraction
- `ApplicationName` validate special characters that affect output results creation 
- `ClickFilter` validate regex expressions 

2. Add webdriver CI test for Linux and macOS

3. Bug fixing:
- If SUTConnectorValue is empty, show a message and finish the main process
- Fix Android Spy mode screenshot

4. Update selenium and Dockerfile dependencies