### PR TITLE
Adding option to disable search engine selector on chromedriver

### DIFF
--- a/testar/src/org/testar/monkey/Main.java
+++ b/testar/src/org/testar/monkey/Main.java
@@ -58,7 +58,7 @@ import static org.testar.monkey.Util.compileProtocol;
 
 public class Main {
 
-	public static final String TESTAR_VERSION = "2.6.17 (24-Jul-2024)";
+	public static final String TESTAR_VERSION = "2.6.18 (30-Jul-2024)";
 
 	//public static final String TESTAR_DIR_PROPERTY = "DIRNAME"; //Use the OS environment to obtain TESTAR directory
 	public static final String SETTINGS_FILE = "test.settings";

--- a/webdriver/src/org/testar/monkey/alayer/webdriver/WdDriver.java
+++ b/webdriver/src/org/testar/monkey/alayer/webdriver/WdDriver.java
@@ -180,6 +180,7 @@ public class WdDriver extends SUTBase {
 
     // Workaround to fix https://github.com/SeleniumHQ/selenium/issues/11750
     options.addArguments("--remote-allow-origins=*");
+    options.addArguments("--disable-search-engine-choice-screen");  // Disable search engine selector
 
     return new ChromeDriver(service, options);
   }


### PR DESCRIPTION
Fix for issue #399 

Chromedriver's [option ](https://github.com/GoogleChrome/chrome-launcher/blob/d6be1f3250ef7ff7648ae58c4e92e48509bdbe7c/docs/chrome-flags-for-tools.md?plain=1#L23) to disable the search engine selector form was added to the WdDriver.